### PR TITLE
[v3] Only throw qpsolvers-owned exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Exception ``ParamError`` for incorrect solver parameters
+- Exception ``SolverError`` for solver failures
+
 ### Changed
 
+- All functions throw only qpsolvers-owned exceptions
+- CVXOPT: rethrow ``ValueError`` as either ``ProblemError`` or ``SolverError``
 - Install open source solvers with wheels by default
 - Remove ``solve_safer_qp``
 - Remove ``sym_proj`` parameter
@@ -28,23 +35,15 @@ All notable changes to this project will be documented in this file.
 - qpOASES: fix missing lower bound when there is no equality constraint
 - qpOASES: handle infinite bounds
 - qpOASES: segmentation fault with conda feedstock
-- ParamError exception for incorrect solver parameters
-- ProblemError exception for malformed quadratic programs
-- SolverError exception for solver failures
-
-### Changed
-
-- All functions throw only qpsolvers-owned exceptions
-- CVXOPT: rethrow ValueError exceptions as either ProblemError or SolverError
 
 ## [2.7.2] - 2023/01/02
 
 ### Added
 
 - ECOS: handle two more exit flags
-- ProblemError exception
+- Exception ``ProblemError`` for problem formulation errors
+- Exception ``QPError`` as a base class for exceptions
 - Property to check if a Problem has sparse matrices
-- QPError base class for exceptions
 - qpOASES: raise a ProblemError when matrices are not dense
 - qpSWIFT: raise a ProblemError when matrices are not dense
 - quadprog: raise a ProblemError when matrices are not dense

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - All functions throw only qpsolvers-owned exceptions
+- CVXOPT: rethrow ValueError exceptions as either ProblemError or SolverError
 
 ## [2.7.2] - 2023/01/02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ All notable changes to this project will be documented in this file.
 - qpOASES: fix missing lower bound when there is no equality constraint
 - qpOASES: handle infinite bounds
 - qpOASES: segmentation fault with conda feedstock
+- ParamError exception for incorrect solver parameters
+- ProblemError exception for malformed quadratic programs
+- SolverError exception for solver failures
+
+### Changed
+
+- All functions throw only qpsolvers-owned exceptions
 
 ## [2.7.2] - 2023/01/02
 

--- a/qpsolvers/__init__.py
+++ b/qpsolvers/__init__.py
@@ -20,7 +20,14 @@
 
 """Quadratic programming solvers in Python with a unified API."""
 
-from .exceptions import ProblemError
+from .exceptions import (
+    NoSolverSelected,
+    ParamError,
+    ProblemError,
+    QPError,
+    SolverError,
+    SolverNotFound,
+)
 from .problem import Problem
 from .solution import Solution
 from .solve_ls import solve_ls
@@ -46,9 +53,14 @@ from .utils import print_matrix_vector
 __version__ = "2.7.4"
 
 __all__ = [
+    "NoSolverSelected",
+    "ParamError",
     "Problem",
     "ProblemError",
+    "QPError",
     "Solution",
+    "SolverError",
+    "SolverNotFound",
     "__version__",
     "available_solvers",
     "cvxopt_solve_qp",

--- a/qpsolvers/__init__.py
+++ b/qpsolvers/__init__.py
@@ -50,7 +50,7 @@ from .solvers import (
 )
 from .utils import print_matrix_vector
 
-__version__ = "2.7.4"
+__version__ = "3.0.0rc0"
 
 __all__ = [
     "NoSolverSelected",

--- a/qpsolvers/conversions/linear_from_box_inequalities.py
+++ b/qpsolvers/conversions/linear_from_box_inequalities.py
@@ -25,6 +25,8 @@ from typing import Optional, Tuple, Union
 import numpy as np
 import scipy.sparse as spa
 
+from ..exceptions import ProblemError
+
 
 def concatenate_bound(
     G: Optional[Union[np.ndarray, spa.csc_matrix]],
@@ -66,7 +68,9 @@ def concatenate_bound(
             G = spa.vstack([G, sign * spa.eye(n)], format="csc")
         else:  # G is not an instance of a type we know
             name = type(G).__name__
-            raise TypeError(f"invalid type '{name}' for inequality matrix G")
+            raise ProblemError(
+                f"invalid type '{name}' for inequality matrix G"
+            )
         h = np.concatenate((h, sign * b))
     return (G, h)
 

--- a/qpsolvers/conversions/socp_from_qp.py
+++ b/qpsolvers/conversions/socp_from_qp.py
@@ -26,6 +26,8 @@ from numpy import hstack, ndarray, sqrt, vstack, zeros
 from numpy.linalg import LinAlgError, cholesky
 from scipy.sparse import csc_matrix
 
+from ..exceptions import ProblemError
+
 
 def socp_from_qp(
     P: ndarray, q: ndarray, G: Optional[ndarray], h: Optional[ndarray]
@@ -93,7 +95,7 @@ def socp_from_qp(
     except LinAlgError as e:
         error = str(e)
         if "not positive definite" in error:
-            raise ValueError("matrix P is not positive definite") from e
+            raise ProblemError("matrix P is not positive definite") from e
         raise e  # other linear algebraic error
 
     scale = 1.0 / sqrt(2)

--- a/qpsolvers/exceptions.py
+++ b/qpsolvers/exceptions.py
@@ -37,7 +37,6 @@ class NoSolverSelected(QPError):
 
 
 class ParamError(QPError):
-
     """Exception raised when solver parameters are incorrect."""
 
 
@@ -50,5 +49,4 @@ class SolverNotFound(QPError):
 
 
 class SolverError(QPError):
-
     """Exception raised when a solver failed."""

--- a/qpsolvers/exceptions.py
+++ b/qpsolvers/exceptions.py
@@ -19,7 +19,7 @@
 # along with qpsolvers. If not, see <http://www.gnu.org/licenses/>.
 
 """
-Exceptions.
+Exceptions from qpsolvers.
 
 We catch all solver exceptions and re-throw them in a qpsolvers-owned exception
 to avoid abstraction leakage. See this `design decision

--- a/qpsolvers/exceptions.py
+++ b/qpsolvers/exceptions.py
@@ -49,6 +49,6 @@ class SolverNotFound(QPError):
     """Exception raised when a requested solver is not found."""
 
 
-class SolverError(Exception):
+class SolverError(QPError):
 
     """Exception raised when a solver failed."""

--- a/qpsolvers/exceptions.py
+++ b/qpsolvers/exceptions.py
@@ -18,7 +18,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with qpsolvers. If not, see <http://www.gnu.org/licenses/>.
 
-"""Exceptions."""
+"""
+Exceptions.
+
+We catch all solver exceptions and re-throw them in a qpsolvers-owned exception
+to avoid abstraction leakage. See this `design decision
+<https://github.com/getparthenon/parthenon/wiki/Design-Decision:-Throw-Custom-Exceptions>`__
+for more details on the rationale behind this choice.
+"""
 
 
 class QPError(Exception):
@@ -29,9 +36,19 @@ class NoSolverSelected(QPError):
     """Exception raised when the `solver` keyword argument is not set."""
 
 
+class ParamError(QPError):
+
+    """Exception raised when solver parameters are incorrect."""
+
+
 class ProblemError(QPError):
     """Exception raised when a quadratic program is malformed."""
 
 
 class SolverNotFound(QPError):
     """Exception raised when a requested solver is not found."""
+
+
+class SolverError(Exception):
+
+    """Exception raised when a solver failed."""

--- a/qpsolvers/problem.py
+++ b/qpsolvers/problem.py
@@ -209,17 +209,17 @@ class Problem:
 
         Raises
         ------
-        ValueError
+        ProblemError
             If the constraints are not properly defined.
         """
         if self.G is None and self.h is not None:
-            raise ValueError("incomplete inequality constraint (missing h)")
+            raise ProblemError("incomplete inequality constraint (missing h)")
         if self.G is not None and self.h is None:
-            raise ValueError("incomplete inequality constraint (missing G)")
+            raise ProblemError("incomplete inequality constraint (missing G)")
         if self.A is None and self.b is not None:
-            raise ValueError("incomplete equality constraint (missing b)")
+            raise ProblemError("incomplete equality constraint (missing b)")
         if self.A is not None and self.b is None:
-            raise ValueError("incomplete equality constraint (missing A)")
+            raise ProblemError("incomplete equality constraint (missing A)")
 
     def cond(self):
         r"""Condition number of the problem matrix.

--- a/qpsolvers/solve_qp.py
+++ b/qpsolvers/solve_qp.py
@@ -109,13 +109,19 @@ def solve_qp(
     NoSolverSelected
         If the ``solver`` keyword argument is not set.
 
-    SolverNotFound
-        If the requested solver is not in :data:`qpsolvers.available_solvers`.
+    ParamError
+        If any solver parameter is incorrect.
 
-    ValueError
+    ProblemError
         If the problem is not correctly defined. For instance, if the solver
         requires a definite cost matrix but the provided matrix :math:`P` is
         not.
+
+    SolverError
+        If the solver failed during its execution.
+
+    SolverNotFound
+        If the requested solver is not in :data:`qpsolvers.available_solvers`.
 
     Notes
     -----

--- a/qpsolvers/solvers/proxqp_.py
+++ b/qpsolvers/solvers/proxqp_.py
@@ -33,6 +33,7 @@ import numpy as np
 import scipy.sparse as spa
 from proxsuite import proxqp
 
+from ..exceptions import ParamError, ProblemError
 from ..problem import Problem
 from ..solution import Solution
 
@@ -59,6 +60,11 @@ def __combine_inequalities(G, h, lb, ub, n: int, use_csc: bool):
     -------
     :
         Linear inequality matrices :math:`C`, :math:`l` and :math:`u`.
+
+    Raises
+    ------
+    ProblemError
+        If the inequality matrix and vector are not consistent.
     """
     if lb is None and ub is None:
         C_prox = G
@@ -81,7 +87,7 @@ def __combine_inequalities(G, h, lb, ub, n: int, use_csc: bool):
         l_prox = np.hstack((np.full(h.shape, -np.infty), lb))
         u_prox = np.hstack((h, ub))
     else:  # G is not None and h is None
-        raise ValueError("Inconsistent inequalities: G is set but h is None")
+        raise ProblemError("Inconsistent inequalities: G is set but h is None")
     return C_prox, u_prox, l_prox
 
 
@@ -100,6 +106,11 @@ def __select_backend(backend: Optional[str], use_csc: bool):
     -------
     :
         Backend solve function.
+
+    Raises
+    ------
+    ParamError
+        If the required backend is not a valid ProxQP backend.
     """
     if backend is None:
         return proxqp.sparse.solve if use_csc else proxqp.dense.solve
@@ -107,7 +118,7 @@ def __select_backend(backend: Optional[str], use_csc: bool):
         return proxqp.dense.solve
     if backend == "sparse":
         return proxqp.sparse.solve
-    raise ValueError(f'Unknown ProxQP backend "{backend}')
+    raise ParamError(f'Unknown ProxQP backend "{backend}')
 
 
 def proxqp_solve_problem(
@@ -135,6 +146,12 @@ def proxqp_solve_problem(
     -------
     :
         Solution to the QP returned by the solver.
+
+    Raises
+    ------
+    ParamError
+        If a warm-start value is given both in `initvals` and the `x` keyword
+        argument.
 
     Notes
     -----
@@ -184,7 +201,7 @@ def proxqp_solve_problem(
     """
     if initvals is not None:
         if "x" in kwargs:
-            raise ValueError(
+            raise ParamError(
                 "Warm-start value specified in both `initvals` and `x` kwargs"
             )
         kwargs["x"] = initvals

--- a/qpsolvers/solvers/qpoases_.py
+++ b/qpsolvers/solvers/qpoases_.py
@@ -43,7 +43,7 @@ from qpoases import PyQProblem as QProblem
 from qpoases import PyQProblemB as QProblemB
 from qpoases import PyReturnValue as ReturnValue
 
-from ..exceptions import ProblemError
+from ..exceptions import ParamError, ProblemError
 from ..problem import Problem
 from ..solution import Solution
 
@@ -93,6 +93,11 @@ def __prepare_options(
     -------
     :
         Options for qpOASES.
+
+    Raises
+    ------
+    ParamError
+        If predefined options are not a valid choice for qpOASES.
     """
     options = Options()
 
@@ -108,7 +113,7 @@ def __prepare_options(
     elif predefined_options == "reliable":
         options.setToReliable()
     else:
-        raise ValueError(
+        raise ParamError(
             f"unknown qpOASES pre-defined options {predefined_options}'"
         )
 

--- a/qpsolvers/solvers/quadprog_.py
+++ b/qpsolvers/solvers/quadprog_.py
@@ -62,8 +62,9 @@ def quadprog_solve_problem(
     Raises
     ------
     ProblemError :
-        If the problem is ill-formed in some way, for instance if some matrices
-        are not dense.
+        If the cost matrix of the quadratic program if not positive definite,
+        or if the problem is ill-formed in some way, for instance if some
+        matrices are not dense.
 
     Note
     ----
@@ -110,8 +111,8 @@ def quadprog_solve_problem(
         error_message = str(error)
         if "matrix G is not positive definite" in error_message:
             # quadprog writes G the cost matrix that we write P in this package
-            raise ValueError("matrix P is not positive definite") from error
-        if "no solution" in error_message:
+            raise ProblemError("matrix P is not positive definite") from error
+        if "no solution" in error:
             return Solution(problem)
         warnings.warn(f"quadprog raised a ValueError: {error_message}")
         return Solution(problem)

--- a/qpsolvers/solvers/quadprog_.py
+++ b/qpsolvers/solvers/quadprog_.py
@@ -146,10 +146,6 @@ def __convert_dual_multipliers(
     ----------
     y :
         Dual multipliers from quadprog.
-    n :
-        Number of optimization variables.
-    m :
-        Number of (in)equality constraints.
     meq :
         Number of equality constraints.
     lb :

--- a/qpsolvers/solvers/scs_.py
+++ b/qpsolvers/solvers/scs_.py
@@ -37,6 +37,7 @@ from scipy.sparse.linalg import lsqr
 from scs import solve
 
 from ..conversions import ensure_sparse_matrices
+from ..exceptions import ProblemError
 from ..problem import Problem
 from ..solution import Solution
 
@@ -117,7 +118,7 @@ def __solve_unconstrained(problem: Problem) -> Solution:
     solution.x = lsqr(P, -q)[0]
     cost_check = np.linalg.norm(P @ solution.x + q)
     if cost_check > 1e-8:
-        raise ValueError(
+        raise ProblemError(
             f"problem is unbounded below (cost_check={cost_check:.1e}), "
             "q has component in the nullspace of P"
         )

--- a/tests/test_cvxopt.py
+++ b/tests/test_cvxopt.py
@@ -27,6 +27,8 @@ import scipy.sparse as spa
 from numpy import array, ones
 from numpy.linalg import norm
 
+from qpsolvers.exceptions import SolverError
+
 from .problems import get_sd3310_problem
 from .solved_problems import get_qpsut01
 
@@ -111,6 +113,27 @@ try:
             problem.ub[1] = +np.inf
             x = cvxopt_solve_problem(problem)
             self.assertIsNotNone(x)
+
+        def test_solver_error(self):
+            """
+            Call CVXOPT with infinities, resulting in a SolverError.
+            """
+            problem = get_sd3310_problem()
+            with self.assertRaises(SolverError):
+                problem.h[1] = -np.inf
+                cvxopt_solve_qp(
+                    problem.P,
+                    problem.q,
+                    problem.G,
+                    problem.h,
+                    problem.A,
+                    problem.b,
+                    maxiters=10,
+                    abstol=1e-1,
+                    reltol=1e-1,
+                    feastol=1e-2,
+                    refinement=3,
+                )
 
 
 except ImportError:  # solver not installed

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -48,17 +48,17 @@ class TestProblem(unittest.TestCase):
     def test_check_inequality_constraints(self):
         problem = get_sd3310_problem()
         P, q, G, h, A, b, _, _ = problem.unpack()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ProblemError):
             Problem(P, q, G, None, A, b).check_constraints()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ProblemError):
             Problem(P, q, None, h, A, b).check_constraints()
 
     def test_check_equality_constraints(self):
         problem = get_sd3310_problem()
         P, q, G, h, A, b, _, _ = problem.unpack()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ProblemError):
             Problem(P, q, G, h, A, None).check_constraints()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ProblemError):
             Problem(P, q, G, h, None, b).check_constraints()
 
     def test_cond(self):

--- a/tests/test_proxqp.py
+++ b/tests/test_proxqp.py
@@ -21,6 +21,8 @@
 import unittest
 import warnings
 
+from qpsolvers.exceptions import ParamError, ProblemError
+
 from .problems import get_sd3310_problem
 
 try:
@@ -58,7 +60,7 @@ try:
         def test_invalid_backend(self):
             """Exception raised when asking for an invalid backend."""
             problem = get_sd3310_problem()
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ParamError):
                 proxqp_solve_qp(
                     problem.P,
                     problem.q,
@@ -72,7 +74,7 @@ try:
         def test_double_warm_start(self):
             """Exception when two warm-start values are provided."""
             problem = get_sd3310_problem()
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ParamError):
                 proxqp_solve_qp(
                     problem.P,
                     problem.q,
@@ -92,7 +94,7 @@ try:
             called directly.
             """
             problem = get_sd3310_problem()
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ProblemError):
                 proxqp_solve_qp(
                     problem.P,
                     problem.q,

--- a/tests/test_quadprog.py
+++ b/tests/test_quadprog.py
@@ -26,6 +26,8 @@ import scipy.sparse as spa
 
 from qpsolvers import ProblemError
 
+from qpsolvers.exceptions import ProblemError
+
 from .problems import get_sd3310_problem
 
 try:
@@ -42,7 +44,7 @@ try:
             problem = get_sd3310_problem()
             P, q, G, h, A, b, _, _ = problem.unpack()
             P -= np.eye(3)
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ProblemError):
                 quadprog_solve_qp(P, q, G, h, A, b)
 
         def test_quadprog_value_error(self):

--- a/tests/test_scs.py
+++ b/tests/test_scs.py
@@ -23,6 +23,8 @@ import warnings
 
 import numpy as np
 
+from qpsolvers import ProblemError
+
 from .problems import get_sd3310_problem
 
 try:
@@ -40,7 +42,7 @@ try:
             problem = get_sd3310_problem()
             P, q, _, _, _, _, _, _ = problem.unpack()
             P -= np.eye(3)  # make problem unbounded
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ProblemError):
                 scs_solve_qp(P, q)
 
 

--- a/tests/test_solve_qp.py
+++ b/tests/test_solve_qp.py
@@ -29,8 +29,14 @@ from numpy import array, dot, ones, random
 from numpy.linalg import norm
 from scipy.sparse import csc_matrix
 
-from qpsolvers import available_solvers, solve_qp, sparse_solvers
-from qpsolvers.exceptions import NoSolverSelected, SolverNotFound
+from qpsolvers import (
+    NoSolverSelected,
+    ProblemError,
+    SolverNotFound,
+    available_solvers,
+    solve_qp,
+    sparse_solvers,
+)
 
 from .problems import get_qpmad_demo_problem
 
@@ -678,7 +684,7 @@ class TestSolveQP(unittest.TestCase):
             P = dot(v.reshape(4, 1), v.reshape(1, 4))
             q = array([-1.0, -2, 0, 3e-4])
             # q is in the nullspace of P, so the problem is unbounded below
-            with self.assertRaises(ValueError):
+            with self.assertRaises(ProblemError):
                 solve_qp(P, q, solver=solver)
 
         return test

--- a/tests/test_solve_qp.py
+++ b/tests/test_solve_qp.py
@@ -27,8 +27,6 @@ import numpy as np
 import scipy
 from numpy import array, dot, ones, random
 from numpy.linalg import norm
-from scipy.sparse import csc_matrix
-
 from qpsolvers import (
     NoSolverSelected,
     ProblemError,
@@ -37,6 +35,7 @@ from qpsolvers import (
     solve_qp,
     sparse_solvers,
 )
+from scipy.sparse import csc_matrix
 
 from .problems import get_qpmad_demo_problem
 
@@ -44,7 +43,7 @@ from .problems import get_qpmad_demo_problem
 # achieved by some solvers. Here are the behaviors observed as of March 2022.
 # Unit tests only cover solvers that raise successfully:
 behavior_on_unbounded = {
-    "raise_value_error": ["cvxopt", "ecos", "quadprog", "scs"],
+    "raise": ["cvxopt", "ecos", "quadprog", "scs"],
     "return_crazy_solution": ["qpoases"],
     "return_none": ["osqp"],
 }
@@ -807,7 +806,7 @@ for solver in available_solvers:
         f"test_warmstart_{solver}",
         TestSolveQP.get_test_warmstart(solver),
     )
-    if solver in behavior_on_unbounded["raise_value_error"]:
+    if solver in behavior_on_unbounded["raise"]:
         setattr(
             TestSolveQP,
             f"test_raise_on_unbounded_below_{solver}",


### PR DESCRIPTION
We catch all solver exceptions and re-throw them in a qpsolvers-owned exception to avoid abstraction leakage. See this [design decision](https://github.com/getparthenon/parthenon/wiki/Design-Decision:-Throw-Custom-Exceptions) for more details on the rationale behind this choice.
