### PR TITLE
[v3] Add found attribute to Solution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - All functions throw only qpsolvers-owned exceptions
 - CVXOPT: rethrow ``ValueError`` as either ``ProblemError`` or ``SolverError``
+- Checking ``Solution.is_empty`` becomes ``not Solution.found``
 - Install open source solvers with wheels by default
 - Remove ``solve_safer_qp``
 - Remove ``sym_proj`` parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - Exception ``ParamError`` for incorrect solver parameters
 - Exception ``SolverError`` for solver failures
+- New attribute ``Solution.found``
 
 ### Changed
 

--- a/qpsolvers/solution.py
+++ b/qpsolvers/solution.py
@@ -43,23 +43,20 @@ class Solution:
         Quadratic program the solution corresponds to.
 
     obj :
-        Value of the primal objective at the solution (``None`` if no solution
-        was found).
+        Value of the primal objective at the solution.
 
     x :
-        Solution vector of the primal quadratic program (``None`` if no
-        solution was found).
+        Solution vector for the primal quadratic program.
 
     y :
-        Dual multipliers for equality constraints (``None`` if no solution was
-        found). The dimension of :math:`y` is equal to the number of equality
-        constraints. The values :math:`y_i` can be either positive or negative.
+        Dual multipliers for equality constraints. The dimension of :math:`y`
+        is equal to the number of equality constraints. The values :math:`y_i`
+        can be either positive or negative.
 
     z :
-        Dual multipliers for linear inequality constraints (``None`` if no
-        solution was found). The dimension of :math:`z` is equal to the number
-        of inequalities. The value :math:`z_i` for inequality :math:`i` is
-        always positive.
+        Dual multipliers for linear inequality constraints. The dimension of
+        :math:`z` is equal to the number of inequalities. The value :math:`z_i`
+        for inequality :math:`i` is always positive.
 
         - If :math:`z_i > 0`, the inequality is active at the solution:
           :math:`G_i x = h_i`.
@@ -67,9 +64,8 @@ class Solution:
           :math:`G_i x < h_i`.
 
     z_box :
-        Dual multipliers for box inequality constraints (``None`` if no
-        solution was found). The sign of :math:`z_{box,i}` depends on the
-        active bound:
+        Dual multipliers for box inequality constraints. The sign of
+        :math:`z_{box,i}` depends on the active bound:
 
         - If :math:`z_{box,i} < 0`, then the lower bound :math:`lb_i = x_i` is
           active at the solution.

--- a/qpsolvers/solution.py
+++ b/qpsolvers/solution.py
@@ -82,9 +82,9 @@ class Solution:
         Other outputs, specific to each solver.
     """
 
-    found: Optional[bool] = None
     problem: Problem
     extras: dict = field(default_factory=dict)
+    found: Optional[bool] = None
     obj: Optional[float] = None
     x: Optional[np.ndarray] = None
     y: Optional[np.ndarray] = None

--- a/qpsolvers/solution.py
+++ b/qpsolvers/solution.py
@@ -43,20 +43,24 @@ class Solution:
         Quadratic program the solution corresponds to.
 
     obj :
-        Value of the primal objective at the solution.
+        Value of the primal objective at the solution (can be ``None`` if no
+        solution was found).
 
     x :
-        Solution vector for the primal quadratic program.
+        Solution vector for the primal quadratic program (can be ``None`` if no
+        solution was found).
 
     y :
-        Dual multipliers for equality constraints. The dimension of :math:`y`
-        is equal to the number of equality constraints. The values :math:`y_i`
-        can be either positive or negative.
+        Dual multipliers for equality constraints (can be ``None`` if no
+        solution was found, or if there is no equality constraint). The
+        dimension of :math:`y` is equal to the number of equality constraints.
+        The values :math:`y_i` can be either positive or negative.
 
     z :
-        Dual multipliers for linear inequality constraints. The dimension of
-        :math:`z` is equal to the number of inequalities. The value :math:`z_i`
-        for inequality :math:`i` is always positive.
+        Dual multipliers for linear inequality constraints (can be ``None`` if
+        no solution was found, or if there is no inequality constraint). The
+        dimension of :math:`z` is equal to the number of inequalities. The
+        value :math:`z_i` for inequality :math:`i` is always positive.
 
         - If :math:`z_i > 0`, the inequality is active at the solution:
           :math:`G_i x = h_i`.
@@ -64,7 +68,8 @@ class Solution:
           :math:`G_i x < h_i`.
 
     z_box :
-        Dual multipliers for box inequality constraints. The sign of
+        Dual multipliers for box inequality constraints (can be ``None`` if no
+        solution was found, or if there is no box inequality). The sign of
         :math:`z_{box,i}` depends on the active bound:
 
         - If :math:`z_{box,i} < 0`, then the lower bound :math:`lb_i = x_i` is

--- a/qpsolvers/solution.py
+++ b/qpsolvers/solution.py
@@ -87,11 +87,6 @@ class Solution:
     z: Optional[np.ndarray] = None
     z_box: Optional[np.ndarray] = None
 
-    @property
-    def is_empty(self) -> bool:
-        """Check whether the solution is empty."""
-        return self.x is None
-
     def is_optimal(self, eps_abs: float) -> bool:
         """Check whether the solution is indeed optimal.
 

--- a/qpsolvers/solution.py
+++ b/qpsolvers/solution.py
@@ -34,6 +34,11 @@ class Solution:
 
     Attributes
     ----------
+    found :
+        Did the solver find a solution? This value can be ``True`` if the
+        solver returned a solution, ``False`` if it detected a failure case
+        (for instance an unfeasible problem) or ``None`` otherwise.
+
     problem :
         Quadratic program the solution corresponds to.
 
@@ -77,6 +82,7 @@ class Solution:
         Other outputs, specific to each solver.
     """
 
+    found: Optional[bool] = None
     problem: Problem
     extras: dict = field(default_factory=dict)
     obj: Optional[float] = None

--- a/qpsolvers/solution.py
+++ b/qpsolvers/solution.py
@@ -30,10 +30,13 @@ from .problem import Problem
 
 @dataclass(frozen=False)
 class Solution:
-    """Solution provided by a QP solver to a given problem.
+    """Solution returned by a QP solver for a given problem.
 
     Attributes
     ----------
+    extras :
+        Other outputs, specific to each solver.
+
     found :
         Did the solver find a solution? This value can be ``True`` if the
         solver returned a solution, ``False`` if it detected a failure case
@@ -79,8 +82,14 @@ class Solution:
         - If :math:`z_{box,i} > 0`, then the upper bound :math:`x_i = ub_i` is
           active at the solution.
 
-    extras :
-        Other outputs, specific to each solver.
+    Notes:
+        The best way to check if the QP solver assessed it found a solution is
+        ``Solution.found``. Interfaces capture as much return information from
+        solver return values as possible, therefore other attributes (for
+        example ``Solution.x``) can have values even when ``Solution.found ==
+        False``. One such instance is when a solver reaches a maximum number of
+        iterations before convergence: depending on the use case, the
+        intermediate current ``x`` might still be of interest.
     """
 
     problem: Problem

--- a/qpsolvers/solve_qp.py
+++ b/qpsolvers/solve_qp.py
@@ -143,4 +143,4 @@ def solve_qp(
         )
     problem = Problem(P, q, G, h, A, b, lb, ub)
     solution = solve_problem(problem, solver, initvals, verbose, **kwargs)
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/cvxopt_.py
+++ b/qpsolvers/solvers/cvxopt_.py
@@ -276,6 +276,4 @@ def cvxopt_solve_qp(
     solution = cvxopt_solve_problem(
         problem, solver, initvals, verbose, **kwargs
     )
-    if not solution.found:
-        return None
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/cvxopt_.py
+++ b/qpsolvers/solvers/cvxopt_.py
@@ -182,8 +182,7 @@ def cvxopt_solve_problem(
     cvxopt.solvers.options = original_options
 
     solution = Solution(problem)
-    if "optimal" not in res["status"]:
-        return solution
+    solution.found = "optimal" in res["status"]
     solution.x = np.array(res["x"]).reshape((q.shape[0],))
     if b is not None:
         solution.y = np.array(res["y"]).reshape((b.shape[0],))
@@ -277,4 +276,6 @@ def cvxopt_solve_qp(
     solution = cvxopt_solve_problem(
         problem, solver, initvals, verbose, **kwargs
     )
+    if not solution.found:
+        return None
     return solution.x

--- a/qpsolvers/solvers/ecos_.py
+++ b/qpsolvers/solvers/ecos_.py
@@ -145,12 +145,11 @@ def ecos_solve_problem(
     else:
         result = solve(c_socp, G_socp, h_socp, dims, **kwargs)
     flag = result["info"]["exitFlag"]
+    solution = Solution(problem)
+    solution.found = flag == 0
     if flag != 0:
         meaning = __exit_flag_meaning__.get(flag, "unknown exit flag")
         warnings.warn(f"ECOS returned exit flag {flag} ({meaning})")
-        return Solution(problem)
-
-    solution = Solution(problem)
     solution.x = result["x"][:-1]
     if A is not None:
         solution.y = result["y"]
@@ -253,4 +252,6 @@ def ecos_solve_qp(
     """
     problem = Problem(P, q, G, h, A, b, lb, ub)
     solution = ecos_solve_problem(problem, initvals, verbose, **kwargs)
+    if not solution.found:
+        return None
     return solution.x

--- a/qpsolvers/solvers/ecos_.py
+++ b/qpsolvers/solvers/ecos_.py
@@ -252,6 +252,4 @@ def ecos_solve_qp(
     """
     problem = Problem(P, q, G, h, A, b, lb, ub)
     solution = ecos_solve_problem(problem, initvals, verbose, **kwargs)
-    if not solution.found:
-        return None
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/gurobi_.py
+++ b/qpsolvers/solvers/gurobi_.py
@@ -123,8 +123,7 @@ def gurobi_solve_problem(
 
     solution = Solution(problem)
     solution.extras["status"] = model.status
-    if model.status not in (GRB.OPTIMAL, GRB.SUBOPTIMAL):
-        return solution
+    solution.found = model.status in (GRB.OPTIMAL, GRB.SUBOPTIMAL)
     solution.x = x.X
     __retrieve_dual(solution, ineq_constr, eq_constr, lb_constr, ub_constr)
     return solution
@@ -238,4 +237,4 @@ def gurobi_solve_qp(
     """
     problem = Problem(P, q, G, h, A, b, lb, ub)
     solution = gurobi_solve_problem(problem, initvals, verbose, **kwargs)
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/gurobi_.py
+++ b/qpsolvers/solvers/gurobi_.py
@@ -124,6 +124,8 @@ def gurobi_solve_problem(
     solution = Solution(problem)
     solution.extras["status"] = model.status
     solution.found = model.status in (GRB.OPTIMAL, GRB.SUBOPTIMAL)
+    if not solution.found:
+        return solution
     solution.x = x.X
     __retrieve_dual(solution, ineq_constr, eq_constr, lb_constr, ub_constr)
     return solution

--- a/qpsolvers/solvers/highs_.py
+++ b/qpsolvers/solvers/highs_.py
@@ -213,8 +213,7 @@ def highs_solve_problem(
     model_status = solver.getModelStatus()
 
     solution = Solution(problem)
-    if model_status != highspy.HighsModelStatus.kOptimal:
-        return solution
+    solution.found = model_status == highspy.HighsModelStatus.kOptimal
     solution.x = np.array(result.col_value)
     if G is not None:
         solution.z = -np.array(result.row_dual[: G.shape[0]])
@@ -309,4 +308,4 @@ def highs_solve_qp(
     """
     problem = Problem(P, q, G, h, A, b, lb, ub)
     solution = highs_solve_problem(problem, initvals, verbose, **kwargs)
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/mosek_.py
+++ b/qpsolvers/solvers/mosek_.py
@@ -142,4 +142,4 @@ def mosek_solve_qp(
     """
     problem = Problem(P, q, G, h, A, b, lb, ub)
     solution = mosek_solve_problem(problem, initvals, verbose, **kwargs)
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/osqp_.py
+++ b/qpsolvers/solvers/osqp_.py
@@ -151,9 +151,9 @@ def osqp_solve_problem(
     success_status = osqp.constant("OSQP_SOLVED")
 
     solution = Solution(problem)
-    if res.info.status_val != success_status:
+    solution.found = res.info.status_val == success_status
+    if not solution.found:
         warnings.warn(f"OSQP exited with status '{res.info.status}'")
-        return solution
     solution.x = res.x
     m = G.shape[0] if G is not None else 0
     meq = A.shape[0] if A is not None else 0
@@ -285,4 +285,4 @@ def osqp_solve_qp(
     """
     problem = Problem(P, q, G, h, A, b, lb, ub)
     solution = osqp_solve_problem(problem, initvals, verbose, **kwargs)
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/proxqp_.py
+++ b/qpsolvers/solvers/proxqp_.py
@@ -227,8 +227,7 @@ def proxqp_solve_problem(
     )
     solution = Solution(problem)
     solution.extras = {"info": result.info}
-    if result.info.status != proxqp.QPSolverOutput.PROXQP_SOLVED:
-        return solution
+    solution.found = result.info.status == proxqp.QPSolverOutput.PROXQP_SOLVED
     solution.x = result.x
     solution.y = result.y
     if lb is not None or ub is not None:
@@ -306,4 +305,4 @@ def proxqp_solve_qp(
     solution = proxqp_solve_problem(
         problem, initvals, verbose, backend, **kwargs
     )
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/qpoases_.py
+++ b/qpsolvers/solvers/qpoases_.py
@@ -278,11 +278,12 @@ def qpoases_solve_problem(
         raise ProblemError("problem has sparse matrices") from error
 
     solution = Solution(problem)
+    solution.found = True
     if RET_INIT_FAILED <= return_value <= RET_INIT_FAILED_REGULARISATION:
-        return solution
+        solution.found = False
     if return_value == ReturnValue.MAX_NWSR_REACHED:
         warnings.warn(f"qpOASES reached the maximum number of WSR ({max_wsr})")
-        return solution
+        solution.found = False
 
     x_opt = np.empty((n,))
     z_opt = np.empty((n + C.shape[0],))
@@ -424,4 +425,4 @@ def qpoases_solve_qp(
         predefined_options,
         **kwargs,
     )
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/qpswift_.py
+++ b/qpsolvers/solvers/qpswift_.py
@@ -159,8 +159,7 @@ def qpswift_solve_problem(
     solution.extras["advInfo"] = adv_info
     solution.obj = adv_info["fval"]
     exit_flag = basic_info["ExitFlag"]
-    if exit_flag != 0:
-        return solution
+    solution.found = exit_flag == 0
     solution.x = result["sol"]
     if A is not None:
         solution.y = adv_info["y"]
@@ -303,4 +302,4 @@ def qpswift_solve_qp(
     """
     problem = Problem(P, q, G, h, A, b, lb, ub)
     solution = qpswift_solve_problem(problem, initvals, verbose, **kwargs)
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/quadprog_.py
+++ b/qpsolvers/solvers/quadprog_.py
@@ -112,12 +112,15 @@ def quadprog_solve_problem(
         if "matrix G is not positive definite" in error_message:
             # quadprog writes G the cost matrix that we write P in this package
             raise ProblemError("matrix P is not positive definite") from error
+        no_solution = Solution(problem)
+        no_solution.found = False
         if "no solution" in error_message:
-            return Solution(problem)
+            return no_solution
         warnings.warn(f"quadprog raised a ValueError: {error_message}")
-        return Solution(problem)
+        return no_solution
 
     solution = Solution(problem)
+    solution.found = True
     solution.x = x
     solution.obj = obj
 
@@ -233,4 +236,4 @@ def quadprog_solve_qp(
     """
     problem = Problem(P, q, G, h, A, b, lb, ub)
     solution = quadprog_solve_problem(problem, initvals, verbose, **kwargs)
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/scs_.py
+++ b/qpsolvers/solvers/scs_.py
@@ -219,11 +219,11 @@ def scs_solve_problem(
     solution = Solution(problem)
     solution.extras = result["info"]
     status_val = result["info"]["status_val"]
+    solution.found = status_val == 1
     if status_val != 1:
         warnings.warn(
             f"SCS returned {status_val}: {__status_val_meaning__[status_val]}"
         )
-        return solution
     solution.x = result["x"]
     meq = A.shape[0] if A is not None else 0
     if A is not None:
@@ -335,4 +335,4 @@ def scs_solve_qp(
     """
     problem = Problem(P, q, G, h, A, b, lb, ub)
     solution = scs_solve_problem(problem, initvals, verbose, **kwargs)
-    return solution.x
+    return solution.x if solution.found else None

--- a/qpsolvers/solvers/scs_.py
+++ b/qpsolvers/solvers/scs_.py
@@ -116,6 +116,7 @@ def __solve_unconstrained(problem: Problem) -> Solution:
     P, q, _, _, _, _, _, _ = problem.unpack()
     solution = Solution(problem)
     solution.x = lsqr(P, -q)[0]
+    solution.found = True
     cost_check = np.linalg.norm(P @ solution.x + q)
     if cost_check > 1e-8:
         raise ProblemError(

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -32,6 +32,7 @@ class TestSolution(unittest.TestCase):
 
     def test_empty(self):
         solution = Solution(get_sd3310_problem())
+        self.assertTrue(solution.found is None)
         self.assertTrue(solution.is_empty)
 
     def test_residuals(self):

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -30,10 +30,9 @@ from .problems import get_sd3310_problem
 class TestSolution(unittest.TestCase):
     """Test fixture for solutions."""
 
-    def test_empty(self):
+    def test_found_default(self):
         solution = Solution(get_sd3310_problem())
         self.assertTrue(solution.found is None)
-        self.assertTrue(solution.is_empty)
 
     def test_residuals(self):
         problem = get_sd3310_problem()

--- a/tests/test_unfeasible_problem.py
+++ b/tests/test_unfeasible_problem.py
@@ -39,7 +39,7 @@ class UnfeasibleProblem(unittest.TestCase):
         """
         warnings.simplefilter("ignore", category=UserWarning)
 
-    def get_dense_problem(self):
+    def get_unfeasible_problem(self):
         """
         Get problem as a sextuple of values to unpack.
 
@@ -84,7 +84,7 @@ class UnfeasibleProblem(unittest.TestCase):
         """
 
         def test(self):
-            P, q, G, h, A, b = self.get_dense_problem()
+            P, q, G, h, A, b = self.get_unfeasible_problem()
             x = solve_qp(P, q, G, h, A, b, solver=solver)
             self.assertIsNone(x)
 


### PR DESCRIPTION
This PR adds a ``Solution.found`` attribute.

Previously, ``Solution.x`` being ``None`` was used to check whether the solver found a solution or not. The drawback of that choice was that some solvers return primal solutions ``x`` even when they don't identify an optimum (for instance when a maximum number of iterations is reached), and this information was lost.

With this new attribute, we can save any value in ``Solution.x`` while the existence is now checked in ``Solution.found``.