### PR TITLE
Mark QPALM as a sparse solver only

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ conda install -c conda-forge qpsolvers
 | [OSQP](https://osqp.org/) | ``osqp`` | Augmented Lagrangian | Sparse | Apache-2.0 | ✔️ |
 | [PIQP](https://github.com/PREDICT-EPFL/piqp) | ``piqp`` | Proximal Interior Point | Dense & Sparse | BSD-2-Clause | ✖️ |
 | [ProxQP](https://github.com/Simple-Robotics/proxsuite) | ``proxqp`` | Augmented Lagrangian | Dense & Sparse | BSD-2-Clause | ✔️ |
-| [QPALM](https://github.com/kul-optec/QPALM) | ``qpalm`` | Augmented Lagrangian | Dense & Sparse | LGPL-3.0 | ✔️ |
+| [QPALM](https://github.com/kul-optec/QPALM) | ``qpalm`` | Augmented Lagrangian | Sparse | LGPL-3.0 | ✔️ |
 | [qpOASES](https://github.com/coin-or/qpOASES) | ``qpoases`` | Active set | Dense | LGPL-2.1 | ➖ |
 | [qpSWIFT](https://qpswift.github.io/) | ``qpswift`` | Interior point | Sparse | GPL-3.0 | ✖️ |
 | [quadprog](https://pypi.python.org/pypi/quadprog/) | ``quadprog`` | Active set | Dense | GPL-2.0 | ✖️ |

--- a/qpsolvers/solvers/__init__.py
+++ b/qpsolvers/solvers/__init__.py
@@ -543,7 +543,6 @@ try:
 
     solve_function["qpalm"] = qpalm_solve_problem
     available_solvers.append("qpalm")
-    dense_solvers.append("qpalm")
     sparse_solvers.append("qpalm")
 except ImportError:
     pass


### PR DESCRIPTION
Similarly to OSQP, QPALM's API requires sparse matrices and we issue a warning if dense matrices are provided. This is what defines the difference between `dense_solvers` and `sparse_solvers`.