### PR TITLE
Add Clarabel to the list of supported solvers in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** no default QP solver installed along with the library
 - NPPro: update exit flag value to match new solver API (thanks to @ottapav)
 
+### Fixed
+
+- docs: Add Clarabel to the list of supported solvers
+
 ## [4.2.0] - 2023-12-21
 
 ### Added

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,7 +2,7 @@ name: qpsolvers
 channels:
     - conda-forge
 dependencies:
-    - cmake
+    - clarabel
     - pip >= 21.3.1
     - proxsuite
     - qpsolvers

--- a/doc/supported-solvers.rst
+++ b/doc/supported-solvers.rst
@@ -8,6 +8,12 @@ Solvers that are detected as installed on your machine are listed in:
 
 .. autodata:: qpsolvers.available_solvers
 
+Clarabel
+========
+
+.. automodule:: qpsolvers.solvers.clarabel_
+    :members:
+
 CVXOPT
 ======
 


### PR DESCRIPTION
That was missing from https://github.com/qpsolvers/qpsolvers/pull/175

Closes https://github.com/qpsolvers/qpsolvers/issues/270