### PR TITLE
warning message csc_matrix for piqp when A is None

### DIFF
--- a/qpsolvers/solvers/piqp_.py
+++ b/qpsolvers/solvers/piqp_.py
@@ -173,15 +173,22 @@ def piqp_solve_problem(
     if A is not None and b is None:
         raise ProblemError("Inconsistent inequalities: A is set but b is None")
     # PIQP does not support A, b, G, and h to be None.
-    G_piqp = np.zeros((0, n)) if G is None else G
-    h_piqp = np.zeros((0,)) if h is None else h
-    A_piqp = np.zeros((0, n)) if A is None else A
-    b_piqp = np.zeros((0,)) if b is None else b
     use_csc: bool = (
         not isinstance(P, np.ndarray)
         or (G is not None and not isinstance(G, np.ndarray))
         or (A is not None and not isinstance(A, np.ndarray))
     )
+    G_piqp = np.zeros((0, n)) if G is None else G
+    h_piqp = np.zeros((0,)) if h is None else h
+    if A is None:
+        if use_csc is True:
+            A_piqp = spa.csc_matrix(np.zeros((0, n)))
+        else:
+            A_piqp = np.zeros((0, n))
+    else:
+        A
+    b_piqp = np.zeros((0,)) if b is None else b
+
     if use_csc is True:
         P, G_piqp, A_piqp = ensure_sparse_matrices(P, G_piqp, A_piqp)
 


### PR DESCRIPTION
Running ```ipython -i test_model_predictive_control.py``` generates a warning message to convert from np.ndarray to csc_matrix: "ensure_sparse_matrices.py:24: UserWarning: Converted A to scipy.sparse.csc.csc_matrix
For best performance, build A as a scipy.sparse.csc_matrix rather than as a numpy.ndarray
  warnings.warn(". 

Original code: 
```python
# PIQP does not support A, b, G, and h to be None.
  G_piqp = np.zeros((0, n)) if G is None else G
  h_piqp = np.zeros((0,)) if h is None else h
  A_piqp = np.zeros((0, n)) if A is None else A
  b_piqp = np.zeros((0,)) if b is None else b
  use_csc: bool = (
      not isinstance(P, np.ndarray)
      or (G is not None and not isinstance(G, np.ndarray))
      or (A is not None and not isinstance(A, np.ndarray))
)
```

Changed code: 
```python 
# PIQP does not support A, b, G, and h to be None.
  use_csc: bool = (
      not isinstance(P, np.ndarray)
      or (G is not None and not isinstance(G, np.ndarray))
      or (A is not None and not isinstance(A, np.ndarray))
  )
  G_piqp = np.zeros((0, n)) if G is None else G
  h_piqp = np.zeros((0,)) if h is None else h
  if A is None:
      if use_csc is True:
          A_piqp = spa.csc_matrix(np.zeros((0, n)))
      else:
          A_piqp = np.zeros((0, n))
  else:
      A

``