### PR TITLE
Remove Python 3.8 from continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
             - name: "Checkout sources"
               uses: actions/checkout@v3
 
-            - name: "Set up Python 3.8"
+            - name: "Set up Python 3.9"
               uses: actions/setup-python@v4
               with:
-                  python-version: "3.8"
+                  python-version: "3.9"
 
             - name: "Install dependencies"
               run: |
@@ -71,10 +71,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]
-                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-                exclude:
-                    - os: macos-latest
-                      python-version: "3.8"
+                python-version: ["3.9", "3.10", "3.11", "3.12"]
 
         steps:
             - name: "Checkout sources"
@@ -134,7 +131,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest, windows-latest]
-                python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+                python-version: ["3.9", "3.10", "3.11", "3.12"]
 
         steps:
             - name: "Checkout sources"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump minimum Python version to 3.8
+- CICD: Remove Python 3.8 from continuous integration
 - Fix output datatypes when splitting linear-box dual multipliers
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py{38,39,310,311,312}-{linux,macos,windows}
 
 [gh-actions]
 python =
-    3.8: py38
     3.9: py39
     3.10: py310
     3.11: py311


### PR DESCRIPTION
Python 3.8 has reached its end of life: https://devguide.python.org/versions/