### PR TITLE
Release v4.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.5.1] - 2025-03-04
+
 ### Changed
 
 - CICD: Update checkout action to v4
+
+### Fixed
+
+- OSQP: Temporary fix in returning primal-dual infeasibility certificates
 
 ## [4.5.0] - 2025-03-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.5.1] - 2025-03-04
+## [4.5.1] - 2025-04-10
 
 ### Changed
 
@@ -786,7 +786,8 @@ release!
 
 - A changelog :)
 
-[unreleased]: https://github.com/qpsolvers/qpsolvers/compare/v4.5.0...HEAD
+[unreleased]: https://github.com/qpsolvers/qpsolvers/compare/v4.5.1...HEAD
+[4.5.1]: https://github.com/qpsolvers/qpsolvers/compare/v4.5.0...v4.5.1
 [4.5.0]: https://github.com/qpsolvers/qpsolvers/compare/v4.4.0...v4.5.0
 [4.4.0]: https://github.com/qpsolvers/qpsolvers/compare/v4.3.3...v4.4.0
 [4.3.3]: https://github.com/qpsolvers/qpsolvers/compare/v4.3.2...v4.3.3

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "qpsolvers: Quadratic Programming Solvers in Python"
-version: 4.5.0
+version: 4.5.1
 date-released: 2025-03-04
 url: "https://github.com/qpsolvers/qpsolvers"
 license: "LGPL-3.0"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you find this project useful, please consider giving it a :star: or citing it
   author = {Caron, Stéphane and Arnström, Daniel and Bonagiri, Suraj and Dechaume, Antoine and Flowers, Nikolai and Heins, Adam and Ishikawa, Takuma and Kenefake, Dustin and Mazzamuto, Giacomo and Meoli, Donato and O'Donoghue, Brendan and Oppenheimer, Adam A. and Pandala, Abhishek and Quiroz Omaña, Juan José and Rontsis, Nikitas and Shah, Paarth and St-Jean, Samuel and Vitucci, Nicola and Wolfers, Soeren and Yang, Fengyu and @bdelhaisse and @MeindertHH and @rimaddo and @urob and @shaoanlu and Khalil, Ahmed and Kozlov, Lev},
   license = {LGPL-3.0},
   url = {https://github.com/qpsolvers/qpsolvers},
-  version = {4.5.0},
+  version = {4.5.1},
   year = {2025}
 }
 ```

--- a/qpsolvers/__init__.py
+++ b/qpsolvers/__init__.py
@@ -43,7 +43,7 @@ from .solvers import (
 from .unsupported import nppro_solve_qp
 from .utils import print_matrix_vector
 
-__version__ = "4.5.0"
+__version__ = "4.5.1"
 
 __all__ = [
     "ActiveSet",

--- a/qpsolvers/solvers/osqp_.py
+++ b/qpsolvers/solvers/osqp_.py
@@ -137,11 +137,14 @@ def osqp_solve_problem(
     success_status = osqp.constant("OSQP_SOLVED")
 
     solution = Solution(problem)
-    solution.extras = {
-        "dual_inf_cert": res.dual_inf_cert,
-        "info": res.info,
-        "prim_inf_cert": res.prim_inf_cert,
-    }
+    solution.extras = {"info": res.info}
+
+    # Temporary, see https://github.com/osqp/osqp-python/issues/174
+    if hasattr(res, "dual_inf_cert"):
+        solution.extras["dual_inf_cert"] = res.dual_inf_cert
+    if hasattr(res, "prim_inf_cert"):
+        solution.extras["prim_inf_cert"] = res.prim_inf_cert
+
     solution.found = res.info.status_val == success_status
     if not solution.found:
         warnings.warn(f"OSQP exited with status '{res.info.status}'")


### PR DESCRIPTION
This patch release adds a workaround to handle OSQP infeasibility certificates with both pre-1.0 and 1.0.3 versions of the solver.

### Changed

- CICD: Update checkout action to v4

### Fixed

- OSQP: Temporary fix in returning primal-dual infeasibility certificates
