### PR TITLE
Define qpsolvers-related warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add solver name argument to internal `ensure_sparse_matrices` function
 
+### Removed
+
+- Warning that was issued every time an unsupported solver is available
+
 ## [4.6.0] - 2025-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- warnings: Add `SparseConversionWarning` to filter the corresponding warning
+- warnings: Base class `QPWarning` for all qpsolvers-related warnings
+- warnings: Recall solver name when issuing conversion warnings
+
+### Changed
+
+- Add solver name argument to internal `ensure_sparse_matrices` function
+
 ## [4.6.0] - 2025-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ If you find this project useful, please consider giving it a :star: or citing it
 }
 ```
 
+Don't forget to add yourself to the BibTeX above and to `CITATION.cff` if you contribute to this repository.
+
 ## Contributing
 
 We welcome contributions! The first step is to install the library and use it. Report any bug in the [issue tracker](https://github.com/qpsolvers/qpsolvers/issues). If you're a developer looking to hack on open source, check out the [contribution guidelines](https://github.com/qpsolvers/qpsolvers/blob/main/CONTRIBUTING.md) for suggestions.

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,14 +1,16 @@
-name: qpsolvers
+name: qpsolvers_doc
 channels:
     - conda-forge
 dependencies:
     - clarabel
+    - cvxopt
     - daqp
+    - kvxopt
     - pip >= 21.3.1
     - proxsuite
     - python=3.10
     - qpsolvers
-    - kvxopt
+    - quadprog
     - pip:
         - furo >= 2023.8.17
         - highspy >= 1.5.3

--- a/qpsolvers/_internals.py
+++ b/qpsolvers/_internals.py
@@ -6,15 +6,11 @@
 
 """Internal objects."""
 
-import warnings
-
 from .solvers import available_solvers as supported_solvers
 from .solvers import solve_function as supported_solve
 from .unsupported import available_solvers as unsupported_solvers
 from .unsupported import solve_function as unsupported_solve
 
 available_solvers = supported_solvers + unsupported_solvers
-for solver in unsupported_solvers:
-    warnings.warn(f'QP solver "{solver}" is available but unsupported')
 
 solve_function = {**supported_solve, **unsupported_solve}

--- a/qpsolvers/conversions/ensure_sparse_matrices.py
+++ b/qpsolvers/conversions/ensure_sparse_matrices.py
@@ -12,19 +12,23 @@ from typing import Optional, Tuple, Union
 import numpy as np
 import scipy.sparse as spa
 
+from ..warnings import SparseConversionWarning
 
-def __warn_about_sparse_conversion(matrix_name: str) -> None:
+def __warn_about_sparse_conversion(matrix_name: str, solver_name: str) -> None:
     """Warn about conversion from dense to sparse matrix.
 
     Parameters
     ----------
     matrix_name :
         Name of matrix being converted from dense to sparse.
+    solver_name :
+        Name of the QP solver matrices will be passed to.
     """
     warnings.warn(
-        f"Converted {matrix_name} to scipy.sparse.csc.csc_matrix\n"
-        f"For best performance, build {matrix_name} as a "
-        "scipy.sparse.csc_matrix rather than as a numpy.ndarray"
+        f"Converted matrix '{matrix_name}' of your problem to "
+        f"scipy.sparse.csc_matrix to pass it to solver '{solver_name}'; "
+        f"for best performance, build your matrix as a csc_matrix directly.",
+        category=SparseConversionWarning,
     )
 
 
@@ -51,12 +55,12 @@ def ensure_sparse_matrices(
         Tuple of all three matrices as sparse matrices.
     """
     if isinstance(P, np.ndarray):
-        __warn_about_sparse_conversion("P")
+        __warn_about_sparse_conversion("P", solver_name)
         P = spa.csc_matrix(P)
     if isinstance(G, np.ndarray):
-        __warn_about_sparse_conversion("G")
+        __warn_about_sparse_conversion("G", solver_name)
         G = spa.csc_matrix(G)
     if isinstance(A, np.ndarray):
-        __warn_about_sparse_conversion("A")
+        __warn_about_sparse_conversion("A", solver_name)
         A = spa.csc_matrix(A)
     return P, G, A

--- a/qpsolvers/conversions/ensure_sparse_matrices.py
+++ b/qpsolvers/conversions/ensure_sparse_matrices.py
@@ -33,6 +33,7 @@ def __warn_about_sparse_conversion(matrix_name: str, solver_name: str) -> None:
 
 
 def ensure_sparse_matrices(
+    solver_name: str,
     P: Union[np.ndarray, spa.csc_matrix],
     G: Optional[Union[np.ndarray, spa.csc_matrix]],
     A: Optional[Union[np.ndarray, spa.csc_matrix]],
@@ -42,6 +43,8 @@ def ensure_sparse_matrices(
 
     Parameters
     ----------
+    solver_name :
+        Name of the QP solver matrices will be passed to.
     P :
         Cost matrix.
     G :

--- a/qpsolvers/conversions/ensure_sparse_matrices.py
+++ b/qpsolvers/conversions/ensure_sparse_matrices.py
@@ -14,6 +14,7 @@ import scipy.sparse as spa
 
 from ..warnings import SparseConversionWarning
 
+
 def __warn_about_sparse_conversion(matrix_name: str, solver_name: str) -> None:
     """Warn about conversion from dense to sparse matrix.
 

--- a/qpsolvers/solvers/clarabel_.py
+++ b/qpsolvers/solvers/clarabel_.py
@@ -89,7 +89,7 @@ def clarabel_solve_problem(
     if initvals is not None and verbose:
         warnings.warn("Clarabel: warm-start values are ignored")
     P, q, G, h, A, b, lb, ub = problem.unpack()
-    P, G, A = ensure_sparse_matrices(P, G, A)
+    P, G, A = ensure_sparse_matrices("clarabel", P, G, A)
     if lb is not None or ub is not None:
         G, h = linear_from_box_inequalities(G, h, lb, ub, use_sparse=True)
 

--- a/qpsolvers/solvers/highs_.py
+++ b/qpsolvers/solvers/highs_.py
@@ -169,7 +169,7 @@ def highs_solve_problem(
     for more information on the solver.
     """
     P, q, G, h, A, b, lb, ub = problem.unpack()
-    P, G, A = ensure_sparse_matrices(P, G, A)
+    P, G, A = ensure_sparse_matrices("highs", P, G, A)
     if initvals is not None:
         warnings.warn(
             "HiGHS: warm-start values are not available for this solver, "

--- a/qpsolvers/solvers/osqp_.py
+++ b/qpsolvers/solvers/osqp_.py
@@ -6,13 +6,13 @@
 
 """Solver interface for `OSQP <https://osqp.org/>`__.
 
-The OSQP solver implements an Operator-Splitting method for large-scale convex
-quadratic programming. It is designed for both dense and sparse problems, and
-convexity is the only assumption it makes on problem data (for instance, it
-does not make any rank assumption contrary to :ref:`CVXOPT <CVXOPT rank
-assumptions>` or :ref:`qpSWIFT <qpSWIFT rank assumptions>`). If you are using
-OSQP in a scientific work, consider citing the corresponding paper
-[Stellato2020]_.
+The OSQP solver implements an operator-splitting method, more precisely an
+alternating direction method of multipliers (ADMM). It is designed for both
+dense and sparse problems, and convexity is the only assumption it makes on
+problem data (for instance, it does not make any rank assumption, contrary to
+solvers such as :ref:`CVXOPT <CVXOPT rank assumptions>` or :ref:`qpSWIFT
+<qpSWIFT rank assumptions>`). If you are using OSQP in a scientific work,
+consider citing the corresponding paper [Stellato2020]_.
 """
 
 import warnings

--- a/qpsolvers/solvers/osqp_.py
+++ b/qpsolvers/solvers/osqp_.py
@@ -106,7 +106,7 @@ def osqp_solve_problem(
     overview of solver tolerances.
     """
     P, q, G, h, A, b, lb, ub = problem.unpack()
-    P, G, A = ensure_sparse_matrices(P, G, A)
+    P, G, A = ensure_sparse_matrices("osqp", P, G, A)
 
     A_osqp = None
     l_osqp = None

--- a/qpsolvers/solvers/piqp_.py
+++ b/qpsolvers/solvers/piqp_.py
@@ -192,7 +192,7 @@ def piqp_solve_problem(
     h_piqp = np.zeros((0,)) if h is None else h
     b_piqp = np.zeros((0,)) if b is None else b
     if use_csc:
-        P, G_piqp, A_piqp = ensure_sparse_matrices(P, G_piqp, A_piqp)
+        P, G_piqp, A_piqp = ensure_sparse_matrices("piqp", P, G_piqp, A_piqp)
 
     solver = __select_backend(backend, use_csc)
     solver.settings.verbose = verbose

--- a/qpsolvers/solvers/qpalm_.py
+++ b/qpsolvers/solvers/qpalm_.py
@@ -104,7 +104,7 @@ def qpalm_solve_problem(
         kwargs["x"] = initvals
 
     P, q, G, h, A, b, lb, ub = problem.unpack()
-    P, G, A = ensure_sparse_matrices(P, G, A)
+    P, G, A = ensure_sparse_matrices("qpalm", P, G, A)
     n: int = q.shape[0]
 
     Cx, ux, lx = combine_linear_box_inequalities(G, h, lb, ub, n, use_csc=True)

--- a/qpsolvers/solvers/scs_.py
+++ b/qpsolvers/solvers/scs_.py
@@ -143,7 +143,7 @@ def scs_solve_problem(
     all available settings.
     """
     P, q, G, h, A, b, lb, ub = problem.unpack()
-    P, G, A = ensure_sparse_matrices(P, G, A)
+    P, G, A = ensure_sparse_matrices("scs", P, G, A)
     n = P.shape[0]
 
     data: Dict[str, Any] = {"P": P, "c": q}

--- a/qpsolvers/warnings.py
+++ b/qpsolvers/warnings.py
@@ -4,9 +4,7 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 # Copyright 2025 Inria
 
-"""
-Warnings from qpsolvers.
-"""
+"""Warnings from qpsolvers."""
 
 
 class QPWarning(UserWarning):

--- a/qpsolvers/warnings.py
+++ b/qpsolvers/warnings.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# Copyright 2025 Inria
+
+"""
+Warnings from qpsolvers.
+"""
+
+
+class QPWarning(UserWarning):
+    """Base class for qpsolvers warnings."""
+
+
+class SparseConversionWarning(QPWarning):
+    """Warning issued when converting NumPy arrays to SciPy sparse matrices."""

--- a/tests/test_solve_problem.py
+++ b/tests/test_solve_problem.py
@@ -365,10 +365,10 @@ class TestSolveProblem(unittest.TestCase):
             self.assertIsNotNone(result.z, f"{solver=}")
             eps_abs = (
                 6e-3
-                if solver in ("osqp", "qpax")
+                if solver in ("jaxopt_osqp", "osqp", "qpax")
                 else (
                     1e-3
-                    if solver in ("jaxopt_osqp", "scs")
+                    if solver in ("scs")
                     else (
                         1e-4 if solver in ("ecos", "highs", "proxqp") else 1e-5
                     )


### PR DESCRIPTION
This PR defines qpsolvers-related warnings, allowing them to be e.g. filtered via the standard [`warnings`](https://docs.python.org/3/library/warnings.html) module.