### PR TITLE
Release v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.7.0] - 2025-05-13
+
 ### Added
 
 - New solver: [SIP](https://github.com/joaospinto/sip_python) (thanks to @joaospinto)
@@ -815,7 +817,8 @@ release!
 
 - A changelog :)
 
-[unreleased]: https://github.com/qpsolvers/qpsolvers/compare/v4.6.0...HEAD
+[unreleased]: https://github.com/qpsolvers/qpsolvers/compare/v4.7.0...HEAD
+[4.7.0]: https://github.com/qpsolvers/qpsolvers/compare/v4.6.0...v4.7.0
 [4.6.0]: https://github.com/qpsolvers/qpsolvers/compare/v4.5.1...v4.6.0
 [4.5.1]: https://github.com/qpsolvers/qpsolvers/compare/v4.5.0...v4.5.1
 [4.5.0]: https://github.com/qpsolvers/qpsolvers/compare/v4.4.0...v4.5.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -58,3 +58,6 @@ authors:
   given-names: "Lev"
 - family-names: "Groudiev"
   given-names: "Antoine"
+- family-names: "Sousa Pinto"
+  given-names: "João"
+  orcid: "https://orcid.org/0000-0003-2469-2809"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "qpsolvers: Quadratic Programming Solvers in Python"
-version: 4.6.0
-date-released: 2025-03-04
+version: 4.7.0
+date-released: 2025-05-13
 url: "https://github.com/qpsolvers/qpsolvers"
 license: "LGPL-3.0"
 authors:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ If you find this project useful, please consider giving it a :star: or citing it
   author = {Caron, Stéphane and Arnström, Daniel and Bonagiri, Suraj and Dechaume, Antoine and Flowers, Nikolai and Heins, Adam and Ishikawa, Takuma and Kenefake, Dustin and Mazzamuto, Giacomo and Meoli, Donato and O'Donoghue, Brendan and Oppenheimer, Adam A. and Pandala, Abhishek and Quiroz Omaña, Juan José and Rontsis, Nikitas and Shah, Paarth and St-Jean, Samuel and Vitucci, Nicola and Wolfers, Soeren and Yang, Fengyu and @bdelhaisse and @MeindertHH and @rimaddo and @urob and @shaoanlu and Khalil, Ahmed and Kozlov, Lev and Groudiev, Antoine and Sousa Pinto, João},
   license = {LGPL-3.0},
   url = {https://github.com/qpsolvers/qpsolvers},
-  version = {4.6.0},
+  version = {4.7.0},
   year = {2025}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ If you find this project useful, please consider giving it a :star: or citing it
 ```bibtex
 @software{qpsolvers,
   title = {{qpsolvers: Quadratic Programming Solvers in Python}},
-  author = {Caron, Stéphane and Arnström, Daniel and Bonagiri, Suraj and Dechaume, Antoine and Flowers, Nikolai and Heins, Adam and Ishikawa, Takuma and Kenefake, Dustin and Mazzamuto, Giacomo and Meoli, Donato and O'Donoghue, Brendan and Oppenheimer, Adam A. and Pandala, Abhishek and Quiroz Omaña, Juan José and Rontsis, Nikitas and Shah, Paarth and St-Jean, Samuel and Vitucci, Nicola and Wolfers, Soeren and Yang, Fengyu and @bdelhaisse and @MeindertHH and @rimaddo and @urob and @shaoanlu and Khalil, Ahmed and Kozlov, Lev and Groudiev, Antoine},
+  author = {Caron, Stéphane and Arnström, Daniel and Bonagiri, Suraj and Dechaume, Antoine and Flowers, Nikolai and Heins, Adam and Ishikawa, Takuma and Kenefake, Dustin and Mazzamuto, Giacomo and Meoli, Donato and O'Donoghue, Brendan and Oppenheimer, Adam A. and Pandala, Abhishek and Quiroz Omaña, Juan José and Rontsis, Nikitas and Shah, Paarth and St-Jean, Samuel and Vitucci, Nicola and Wolfers, Soeren and Yang, Fengyu and @bdelhaisse and @MeindertHH and @rimaddo and @urob and @shaoanlu and Khalil, Ahmed and Kozlov, Lev and Groudiev, Antoine and Sousa Pinto, João},
   license = {LGPL-3.0},
   url = {https://github.com/qpsolvers/qpsolvers},
   version = {4.6.0},

--- a/qpsolvers/__init__.py
+++ b/qpsolvers/__init__.py
@@ -45,7 +45,7 @@ from .solvers import (
 from .unsupported import nppro_solve_qp
 from .utils import print_matrix_vector
 
-__version__ = "4.6.0"
+__version__ = "4.7.0"
 
 __all__ = [
     "ActiveSet",


### PR DESCRIPTION
This release adds [SIP](https://github.com/joaospinto/sip), a sparse interior point solver implemented in C++. Thanks to @joaospinto for implementing this interface 👍

Additionally, this new version adds warning filters and clears out the OSQP version pin.

### Added

- New solver: [SIP](https://github.com/joaospinto/sip_python) (thanks to @joaospinto)
- warnings: Add `SparseConversionWarning` to filter the corresponding warning
- warnings: Base class `QPWarning` for all qpsolvers-related warnings
- warnings: Recall solver name when issuing conversion warnings

### Changed

- Add solver name argument to internal `ensure_sparse_matrices` function
- CICD: Update Python version to 3.10 in coverage job

### Fixed

- docs: Add jaxopt.OSQP to the list of supported solvers

### Removed

- OSQP: Remove pre-1.0 version pin
- OSQP: Update interface after relase of v1.0.4
- Warning that was issued every time an unsupported solver is available



