### PR TITLE
Add `py.typed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `py.typed` file to indicate tools like `mypy` to use type annotations.
+
 ## [4.7.0] - 2025-05-13
 
 ### Added


### PR DESCRIPTION
Fixes #336 

* This follows [these instruction](https://typing.python.org/en/latest/spec/distributing.html#packaging-type-information) originating from [PEP 561](https://peps.python.org/pep-0561/).
* It will indicate to type checkers like mypy that the public type annotations of qpsolvers and all of its sub-packages should be used.

Note that I actually did not add `partial\n` in `py.typed`, because this seems to be only for stub packages (https://peps.python.org/pep-0561/#partial-stub-packages). mypy should understand just fine when type hints are missing, and should not raise errors in these cases.

I also added a changelog entry (not sure if it's needed, I can remove it if you prefer).