### PR TITLE
Release v4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- PIQP: Add support for new API in v0.6.0
+- PIQP: Add support for new API in v0.6.0 (thanks to @RSchwan)
 - PIQP: Add new solver options in documentation
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.8.0] - 2025-07-02
+
 ### Added
 
 - PIQP: Add support for new API in v0.6.0 (thanks to @RSchwan)
-- PIQP: Add new solver options in documentation
+- PIQP: Add new solver options to the documentation (thanks to @RSchwan)
 
 ### Fixed
 
@@ -832,7 +834,8 @@ release!
 
 - A changelog :)
 
-[unreleased]: https://github.com/qpsolvers/qpsolvers/compare/v4.7.1...HEAD
+[unreleased]: https://github.com/qpsolvers/qpsolvers/compare/v4.8.0...HEAD
+[4.8.0]: https://github.com/qpsolvers/qpsolvers/compare/v4.7.1...v4.8.0
 [4.7.1]: https://github.com/qpsolvers/qpsolvers/compare/v4.7.0...v4.7.1
 [4.7.0]: https://github.com/qpsolvers/qpsolvers/compare/v4.6.0...v4.7.0
 [4.6.0]: https://github.com/qpsolvers/qpsolvers/compare/v4.5.1...v4.6.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "qpsolvers: Quadratic Programming Solvers in Python"
-version: 4.7.1
-date-released: 2025-06-03
+version: 4.8.0
+date-released: 2025-07-02
 url: "https://github.com/qpsolvers/qpsolvers"
 license: "LGPL-3.0"
 authors:

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ If you find this project useful, please consider giving it a :star: or citing it
   author = {Caron, Stéphane and Arnström, Daniel and Bonagiri, Suraj and Dechaume, Antoine and Flowers, Nikolai and Heins, Adam and Ishikawa, Takuma and Kenefake, Dustin and Mazzamuto, Giacomo and Meoli, Donato and O'Donoghue, Brendan and Oppenheimer, Adam A. and Pandala, Abhishek and Quiroz Omaña, Juan José and Rontsis, Nikitas and Shah, Paarth and St-Jean, Samuel and Vitucci, Nicola and Wolfers, Soeren and Yang, Fengyu and @bdelhaisse and @MeindertHH and @rimaddo and @urob and @shaoanlu and Khalil, Ahmed and Kozlov, Lev and Groudiev, Antoine and Sousa Pinto, João and Schwan, Roland},
   license = {LGPL-3.0},
   url = {https://github.com/qpsolvers/qpsolvers},
-  version = {4.7.1},
+  version = {4.8.0},
   year = {2025}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ If you find this project useful, please consider giving it a :star: or citing it
 ```bibtex
 @software{qpsolvers,
   title = {{qpsolvers: Quadratic Programming Solvers in Python}},
-  author = {Caron, Stéphane and Arnström, Daniel and Bonagiri, Suraj and Dechaume, Antoine and Flowers, Nikolai and Heins, Adam and Ishikawa, Takuma and Kenefake, Dustin and Mazzamuto, Giacomo and Meoli, Donato and O'Donoghue, Brendan and Oppenheimer, Adam A. and Pandala, Abhishek and Quiroz Omaña, Juan José and Rontsis, Nikitas and Shah, Paarth and St-Jean, Samuel and Vitucci, Nicola and Wolfers, Soeren and Yang, Fengyu and @bdelhaisse and @MeindertHH and @rimaddo and @urob and @shaoanlu and Khalil, Ahmed and Kozlov, Lev and Groudiev, Antoine and Sousa Pinto, João},
+  author = {Caron, Stéphane and Arnström, Daniel and Bonagiri, Suraj and Dechaume, Antoine and Flowers, Nikolai and Heins, Adam and Ishikawa, Takuma and Kenefake, Dustin and Mazzamuto, Giacomo and Meoli, Donato and O'Donoghue, Brendan and Oppenheimer, Adam A. and Pandala, Abhishek and Quiroz Omaña, Juan José and Rontsis, Nikitas and Shah, Paarth and St-Jean, Samuel and Vitucci, Nicola and Wolfers, Soeren and Yang, Fengyu and @bdelhaisse and @MeindertHH and @rimaddo and @urob and @shaoanlu and Khalil, Ahmed and Kozlov, Lev and Groudiev, Antoine and Sousa Pinto, João and Schwan, Roland},
   license = {LGPL-3.0},
   url = {https://github.com/qpsolvers/qpsolvers},
   version = {4.7.1},

--- a/qpsolvers/__init__.py
+++ b/qpsolvers/__init__.py
@@ -45,7 +45,7 @@ from .solvers import (
 from .unsupported import nppro_solve_qp
 from .utils import print_matrix_vector
 
-__version__ = "4.7.1"
+__version__ = "4.8.0"
 
 __all__ = [
     "ActiveSet",


### PR DESCRIPTION
This release adds support for the new API of PIQP v0.6.0, as well as macOS unit testing for KVXOPT.

Thanks to @RSchwan and @sanurielf for contributing to this release :+1: 

### Added

- PIQP: Add support for new API in v0.6.0 (thanks to @RSchwan)
- PIQP: Add new solver options to the documentation (thanks to @RSchwan)

### Fixed

- CICD: Enable macOS tests for KVXOPT (thanks to @sanurielf)

