### PR TITLE
[qpsolvers/solvers/clarabel_.py]: warn when using scipy lsqr

### DIFF
--- a/qpsolvers/solvers/clarabel_.py
+++ b/qpsolvers/solvers/clarabel_.py
@@ -105,6 +105,9 @@ def clarabel_solve_problem(
         b_list.append(h)
         cones.append(clarabel.NonnegativeConeT(h.shape[0]))
     if not A_list:
+        warnings.warn(
+            "QP is unconstrained: solving with SciPy's LSQR rather than clarabel"
+        )
         return solve_unconstrained(problem)
 
     settings = clarabel.DefaultSettings()


### PR DESCRIPTION
Hi Stéphane,
A small contribution from my side: clarabel currently switches to `sp.lsqr` without any warning. this PR just adds a warning for the user that clarabel is not being used.
Please let me know if any changes to the PR are needed.