### PR TITLE
Release v4.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.8.1] - 2025-08-07
+
 ### Changed
 
 - Clarabel: Warn when problem is unconstrained and solved by `lsqr` (thanks to @proyan)
@@ -838,7 +840,8 @@ release!
 
 - A changelog :)
 
-[unreleased]: https://github.com/qpsolvers/qpsolvers/compare/v4.8.0...HEAD
+[unreleased]: https://github.com/qpsolvers/qpsolvers/compare/v4.8.1...HEAD
+[4.8.1]: https://github.com/qpsolvers/qpsolvers/compare/v4.8.0...v4.8.1
 [4.8.0]: https://github.com/qpsolvers/qpsolvers/compare/v4.7.1...v4.8.0
 [4.7.1]: https://github.com/qpsolvers/qpsolvers/compare/v4.7.0...v4.7.1
 [4.7.0]: https://github.com/qpsolvers/qpsolvers/compare/v4.6.0...v4.7.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you find this code helpful, please cite it as below."
 title: "qpsolvers: Quadratic Programming Solvers in Python"
-version: 4.8.0
-date-released: 2025-07-02
+version: 4.8.1
+date-released: 2025-08-07
 url: "https://github.com/qpsolvers/qpsolvers"
 license: "LGPL-3.0"
 authors:
@@ -65,3 +65,5 @@ authors:
   given-names: "Valérian"
 - family-names: "Schwan"
   given-names: "Roland"
+- family-names: "Budhiraja"
+  given-names: "Rohan"

--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ If you find this project useful, please consider giving it a :star: or citing it
 ```bibtex
 @software{qpsolvers,
   title = {{qpsolvers: Quadratic Programming Solvers in Python}},
-  author = {Caron, Stéphane and Arnström, Daniel and Bonagiri, Suraj and Dechaume, Antoine and Flowers, Nikolai and Heins, Adam and Ishikawa, Takuma and Kenefake, Dustin and Mazzamuto, Giacomo and Meoli, Donato and O'Donoghue, Brendan and Oppenheimer, Adam A. and Pandala, Abhishek and Quiroz Omaña, Juan José and Rontsis, Nikitas and Shah, Paarth and St-Jean, Samuel and Vitucci, Nicola and Wolfers, Soeren and Yang, Fengyu and @bdelhaisse and @MeindertHH and @rimaddo and @urob and @shaoanlu and Khalil, Ahmed and Kozlov, Lev and Groudiev, Antoine and Sousa Pinto, João and Schwan, Roland},
+  author = {Caron, Stéphane and Arnström, Daniel and Bonagiri, Suraj and Dechaume, Antoine and Flowers, Nikolai and Heins, Adam and Ishikawa, Takuma and Kenefake, Dustin and Mazzamuto, Giacomo and Meoli, Donato and O'Donoghue, Brendan and Oppenheimer, Adam A. and Pandala, Abhishek and Quiroz Omaña, Juan José and Rontsis, Nikitas and Shah, Paarth and St-Jean, Samuel and Vitucci, Nicola and Wolfers, Soeren and Yang, Fengyu and @bdelhaisse and @MeindertHH and @rimaddo and @urob and @shaoanlu and Khalil, Ahmed and Kozlov, Lev and Groudiev, Antoine and Sousa Pinto, João and Schwan, Roland and Budhiraja, Rohan},
   license = {LGPL-3.0},
   url = {https://github.com/qpsolvers/qpsolvers},
-  version = {4.8.0},
+  version = {4.8.1},
   year = {2025}
 }
 ```

--- a/qpsolvers/__init__.py
+++ b/qpsolvers/__init__.py
@@ -45,7 +45,7 @@ from .solvers import (
 from .unsupported import nppro_solve_qp
 from .utils import print_matrix_vector
 
-__version__ = "4.8.0"
+__version__ = "4.8.1"
 
 __all__ = [
     "ActiveSet",


### PR DESCRIPTION
This patch release makes the Calarabel interface warn properly when forwarding an unconstrained problem to `lsqr`, like the other interfaces already do. Thanks to @proyan for patching this :+1: 

### Changed

- Clarabel: Warn when problem is unconstrained and solved by `lsqr`

