### PR TITLE
Add build and solve time to Solution 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add build and solve timing info
+
 ### Added
 
 - New solver: qpmad (thanks to @ahoarau)

--- a/qpsolvers/solution.py
+++ b/qpsolvers/solution.py
@@ -77,6 +77,8 @@ class Solution:
     y: Optional[np.ndarray] = None
     z: Optional[np.ndarray] = None
     z_box: Optional[np.ndarray] = None
+    build_time: Optional[float] = None
+    solve_time: Optional[float] = None
 
     def is_optimal(self, eps_abs: float) -> bool:
         """Check whether the solution is indeed optimal.

--- a/qpsolvers/solvers/clarabel_.py
+++ b/qpsolvers/solvers/clarabel_.py
@@ -17,6 +17,7 @@ documentation if you have found Clarabel.rs useful in your work.
 **Warm-start:** this solver interface does not support warm starting ❄️
 """
 
+import time
 import warnings
 from typing import Optional, Union
 
@@ -88,6 +89,7 @@ def clarabel_solve_problem(
     solutions at the cost of computation time. See *e.g.* [Caron2022]_ for a
     primer on solver tolerances and residuals.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None and verbose:
         warnings.warn("Clarabel: warm-start values are ignored")
 
@@ -130,7 +132,9 @@ def clarabel_solve_problem(
         # But see https://github.com/PyO3/pyo3/issues/2880
         raise ProblemError("Solver failed to build problem") from exn
 
+    solve_start_time = time.perf_counter()
     result = solver.solve()
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.obj = result.obj_val
@@ -154,6 +158,8 @@ def clarabel_solve_problem(
     else:  # G is None
         solution.z = np.empty((0,))
         solution.z_box = np.empty((0,))
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/copt_.py
+++ b/qpsolvers/solvers/copt_.py
@@ -15,6 +15,7 @@ See the :ref:`installation page <copt-install>` for additional instructions
 on installing this solver.
 """
 
+import time
 import warnings
 from typing import Optional, Sequence, Union
 
@@ -76,6 +77,7 @@ def copt_solve_problem(
     the cost of computation time. See *e.g.* [Caron2022]_ for a primer of
     solver tolerances.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None:
         warnings.warn("warm-start values are ignored by this wrapper")
 
@@ -118,7 +120,9 @@ def copt_solve_problem(
         ub_constr = model.addMConstr(identity, x, COPT.LESS_EQUAL, ub)
     objective = 0.5 * (x @ P @ x) + q @ x  # type: ignore[operator]
     model.setObjective(objective, sense=COPT.MINIMIZE)
+    solve_start_time = time.perf_counter()
     model.solve()
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.extras["status"] = model.status
@@ -129,6 +133,8 @@ def copt_solve_problem(
         # operators such as ">=", so convert to `np.ndarray`
         solution.x = __to_numpy(x.X)  # type: ignore[attr-defined]
         __retrieve_dual(solution, ineq_constr, eq_constr, lb_constr, ub_constr)
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/cvxopt_.py
+++ b/qpsolvers/solvers/cvxopt_.py
@@ -16,6 +16,7 @@ using CVXOPT in a scientific work, consider citing the corresponding report
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Dict, Optional, Union
 
@@ -143,6 +144,7 @@ def cvxopt_solve_problem(
     parameters. See also [Caron2022]_ for a primer on the duality gap, primal
     and dual residuals.
     """
+    build_start_time = time.perf_counter()
     P, q, G, h, A, b, lb, ub = problem.unpack()
     if lb is not None or ub is not None:
         G, h = linear_from_box_inequalities(
@@ -165,6 +167,7 @@ def cvxopt_solve_problem(
     kwargs["show_progress"] = verbose
 
     try:
+        solve_start_time = time.perf_counter()
         res = qp(
             *args,
             solver=solver,
@@ -172,6 +175,7 @@ def cvxopt_solve_problem(
             options=kwargs,
             **constraints,
         )
+        solve_end_time = time.perf_counter()
     except ValueError as exception:
         error = str(exception)
         if "Rank(A)" in error:
@@ -195,6 +199,8 @@ def cvxopt_solve_problem(
         solution.z = np.empty((0,))
         solution.z_box = np.empty((0,))
     solution.obj = res["primal objective"]
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/daqp_.py
+++ b/qpsolvers/solvers/daqp_.py
@@ -12,6 +12,7 @@ It has been developed to solve small/medium scale dense problems.
 **Warm-start:** this solver interface does not support warm starting ❄️
 """
 
+import time
 import warnings
 from ctypes import c_int
 from typing import Optional
@@ -69,6 +70,7 @@ def daqp_solve_problem(
     <https://darnstrom.github.io/daqp/parameters>`_ documentation for
     all available settings.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None and verbose:
         warnings.warn("warm-start values are ignored by DAQP")
 
@@ -116,9 +118,11 @@ def daqp_solve_problem(
     sense = np.zeros(bupper.shape, dtype=c_int)
     sense[ms + mineq :] = 5
 
+    solve_start_time = time.perf_counter()
     x, obj, exitflag, info = daqp.solve(
         H, f, Atot, bupper, blower, sense, **kwargs
     )
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.found = exitflag > 0
@@ -129,6 +133,8 @@ def daqp_solve_problem(
         solution.z_box = info["lam"][:ms]
         solution.z = info["lam"][ms : ms + mineq]
         solution.y = info["lam"][ms + mineq :]
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/ecos_.py
+++ b/qpsolvers/solvers/ecos_.py
@@ -17,6 +17,7 @@ corresponding paper [Domahidi2013]_.
 **Warm-start:** this solver interface does not support warm starting ❄️
 """
 
+import time
 import warnings
 from typing import Optional, Union
 
@@ -124,6 +125,7 @@ def ecos_solve_problem(
     more details. You can also check out [Caron2022]_ for a primer on
     primal-dual residuals or the duality gap.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None:
         warnings.warn("warm-start values are ignored by this wrapper")
 
@@ -147,9 +149,13 @@ def ecos_solve_problem(
         A_socp = spa.hstack(
             [A_sparse, spa.csc_matrix((A.shape[0], 1))], format="csc"
         )
+        solve_start_time = time.perf_counter()
         result = ecos.solve(c_socp, G_socp, h_socp, dims, A_socp, b, **kwargs)
+        solve_end_time = time.perf_counter()
     else:
+        solve_start_time = time.perf_counter()
         result = ecos.solve(c_socp, G_socp, h_socp, dims, **kwargs)
+        solve_end_time = time.perf_counter()
     flag = result["info"]["exitFlag"]
     solution = Solution(problem)
     solution.extras = result["info"]
@@ -170,6 +176,8 @@ def ecos_solve_problem(
         z, z_box = split_dual_linear_box(z_ecos, lb, ub)
         solution.z = z
         solution.z_box = z_box
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/gurobi_.py
+++ b/qpsolvers/solvers/gurobi_.py
@@ -18,6 +18,7 @@ on installing this solver.
 **Warm-start:** this solver interface does not support warm starting ❄️
 """
 
+import time
 import warnings
 from typing import Optional, Union
 
@@ -81,6 +82,7 @@ def gurobi_solve_problem(
     the cost of computation time. See *e.g.* [Caron2022]_ for a primer of
     solver tolerances.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None:
         warnings.warn("warm-start values are ignored by this wrapper")
 
@@ -127,7 +129,9 @@ def gurobi_solve_problem(
         )
     objective = 0.5 * (x @ P @ x) + q @ x  # type: ignore[operator]
     model.setObjective(objective, sense=GRB.MINIMIZE)
+    solve_start_time = time.perf_counter()
     model.optimize()
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.extras["status"] = model.status
@@ -135,6 +139,8 @@ def gurobi_solve_problem(
     if solution.found:
         solution.x = x.getAttr("X")
         __retrieve_dual(solution, ineq_constr, eq_constr, lb_constr, ub_constr)
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/highs_.py
+++ b/qpsolvers/solvers/highs_.py
@@ -16,6 +16,7 @@ work, consider citing the corresponding paper [Huangfu2018]_.
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Optional, Union
 
@@ -171,6 +172,7 @@ def highs_solve_problem(
     Check out the `HiGHS documentation <https://ergo-code.github.io/HiGHS/>`_
     for more information on the solver.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None:
         warnings.warn(
             "HiGHS: warm-start values are not available for this solver, "
@@ -196,7 +198,9 @@ def highs_solve_problem(
     for option, value in kwargs.items():
         solver.setOptionValue(option, value)
     solver.passModel(model)
+    solve_start_time = time.perf_counter()
     solver.run()
+    solve_end_time = time.perf_counter()
 
     result = solver.getSolution()
     model_status = solver.getModelStatus()
@@ -221,6 +225,8 @@ def highs_solve_problem(
         if lb is not None or ub is not None
         else np.empty((0,))
     )
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/hpipm_.py
+++ b/qpsolvers/solvers/hpipm_.py
@@ -15,6 +15,7 @@ HPIPM in a scientific work, consider citing the corresponding paper
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Optional
 
@@ -78,6 +79,7 @@ def hpipm_solve_problem(
        * - ``tol_stat``
          - Stationarity condition tolerance.
     """
+    build_start_time = time.perf_counter()
     P, q, G, h, A, b, lb, ub = problem.unpack()
     if verbose:
         warnings.warn("verbose keyword argument is ignored by HPIPM")
@@ -145,7 +147,9 @@ def hpipm_solve_problem(
         sol.set("v", initvals)
 
     solver = hpipm.hpipm_dense_qp_solver(dim, solver_args)
+    solve_start_time = time.perf_counter()
     solver.solve(qp, sol)
+    solve_end_time = time.perf_counter()
 
     status = solver.get("status")
 
@@ -172,6 +176,8 @@ def hpipm_solve_problem(
         solution.z_box = (sol.get("lam_ub") - sol.get("lam_lb")).flatten()
     else:
         solution.z_box = np.empty((0,))
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/jaxopt_osqp_.py
+++ b/qpsolvers/solvers/jaxopt_osqp_.py
@@ -15,6 +15,7 @@ compilation.
 **Warm-start:** this solver interface does not support warm starting ❄️
 """
 
+import time
 import warnings
 from typing import Optional
 
@@ -61,6 +62,7 @@ def jaxopt_osqp_solve_problem(
     64-bit floating point numbers by setting its `jax_enable_x64`
     configuration.
     """
+    build_start_time = time.perf_counter()
     if problem.is_unconstrained:
         warnings.warn(
             "QP is unconstrained: "
@@ -74,11 +76,13 @@ def jaxopt_osqp_solve_problem(
     G, h = linear_from_box_inequalities(G_0, h_0, lb, ub, use_sparse=False)
 
     osqp = jaxopt.OSQP(**kwargs)
+    solve_start_time = time.perf_counter()
     result = osqp.run(
         params_obj=(jnp.array(P), jnp.array(q)),
         params_eq=(jnp.array(A), jnp.array(b)) if A is not None else None,
         params_ineq=(jnp.array(G), jnp.array(h)) if G is not None else None,
     )
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.x = np.array(result.params.primal)
@@ -101,6 +105,8 @@ def jaxopt_osqp_solve_problem(
         "status": int(result.state.status),
     }
 
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/kvxopt_.py
+++ b/qpsolvers/solvers/kvxopt_.py
@@ -13,6 +13,7 @@ interior-point solver.
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Dict, Optional, Union
 
@@ -142,6 +143,7 @@ def kvxopt_solve_problem(
     parameters. See also [Caron2022]_ for a primer on the duality gap, primal
     and dual residuals.
     """
+    build_start_time = time.perf_counter()
     P, q, G, h, A, b, lb, ub = problem.unpack()
     if lb is not None or ub is not None:
         G, h = linear_from_box_inequalities(
@@ -170,6 +172,7 @@ def kvxopt_solve_problem(
     kwargs["show_progress"] = verbose
 
     try:
+        solve_start_time = time.perf_counter()
         res = qp(
             *args,
             solver=solver,  # type: ignore[arg-type]
@@ -177,6 +180,7 @@ def kvxopt_solve_problem(
             options=kwargs,
             **constraints,  # type: ignore[arg-type]
         )
+        solve_end_time = time.perf_counter()
     except ValueError as exception:
         error = str(exception)
         if "Rank(A)" in error:
@@ -200,6 +204,8 @@ def kvxopt_solve_problem(
         solution.z = np.empty((0,))
         solution.z_box = np.empty((0,))
     solution.obj = res["primal objective"]  # type: ignore[assignment]
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/mosek_.py
+++ b/qpsolvers/solvers/mosek_.py
@@ -14,6 +14,7 @@ sparse problems, in particular for linear or conic quadratic programs.
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Optional, Union
 
@@ -63,6 +64,7 @@ def mosek_solve_problem(
     :
         Solution to the QP, if found, otherwise ``None``.
     """
+    build_start_time = time.perf_counter()
     if problem.is_unconstrained:
         warnings.warn(
             "QP is unconstrained: solving with SciPy's LSQR rather than MOSEK"
@@ -71,7 +73,11 @@ def mosek_solve_problem(
     if "mosek" not in kwargs:
         kwargs["mosek"] = {}
     kwargs["mosek"][mosek.iparam.log] = 1 if verbose else 0
+    solve_start_time = time.perf_counter()
     solution = cvxopt_solve_problem(problem, "mosek", initvals, **kwargs)
+    solve_end_time = time.perf_counter()
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/nppro_.py
+++ b/qpsolvers/solvers/nppro_.py
@@ -11,6 +11,7 @@ method for strictly convex quadratic programming. Currently, it is designed for
 dense problems only.
 """
 
+import time
 import warnings
 from typing import Optional
 
@@ -63,6 +64,7 @@ def nppro_solve_problem(
        * - ``HessianUpdates``
          - Enable Hessian updates or not.
     """
+    build_start_time = time.perf_counter()
     P, q, G, h, A, b, lb, ub = problem.unpack_as_dense()
 
     n = P.shape[0]
@@ -120,7 +122,9 @@ def nppro_solve_problem(
     x0 = np.asarray(x0, order="C", dtype=np.float64)
 
     # Call solver
+    solve_start_time = time.perf_counter()
     x, fval, exitflag, iter_ = solver.solve(P, q, A_, l_, u_, lb_, ub_, x0)
+    solve_end_time = time.perf_counter()
 
     # Store solution
     exitflag_success = 1
@@ -138,6 +142,8 @@ def nppro_solve_problem(
         "cost": fval,
         "iter": iter_,
     }
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/osqp_.py
+++ b/qpsolvers/solvers/osqp_.py
@@ -17,6 +17,7 @@ consider citing the corresponding paper [Stellato2020]_.
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Optional, Union
 
@@ -106,6 +107,7 @@ def osqp_solve_problem(
     solutions at the cost of computation time. See *e.g.* [Caron2022]_ for an
     overview of solver tolerances.
     """
+    build_start_time = time.perf_counter()
     P, q, G, h, A, b, lb, ub = problem.unpack()
     P, G, A = ensure_sparse_matrices("osqp", P, G, A)
 
@@ -134,7 +136,9 @@ def osqp_solve_problem(
     if initvals is not None:
         solver.warm_start(x=initvals)
 
+    solve_start_time = time.perf_counter()
     res = solver.solve()
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.extras = {
@@ -156,6 +160,8 @@ def osqp_solve_problem(
         if lb is not None or ub is not None
         else np.empty((0,))
     )
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/piqp_.py
+++ b/qpsolvers/solvers/piqp_.py
@@ -18,6 +18,7 @@ corresponding paper [Schwan2023]_.
 **Warm-start:** this solver interface does not support warm starting ❄️
 """
 
+import time
 import warnings
 from typing import Optional, Union
 
@@ -163,6 +164,7 @@ def piqp_solve_problem(
     This list is not exhaustive. Check out the `solver documentation
     <https://predict-epfl.github.io/piqp/interfaces/settings>`__ for details.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None and verbose:
         warnings.warn("warm-start values are ignored by PIQP")
 
@@ -229,7 +231,9 @@ def piqp_solve_problem(
         solver.setup(P, q, A_piqp, b_piqp, G_piqp, h_piqp, lb, ub)
     else:
         solver.setup(P, q, A_piqp, b_piqp, G_piqp, None, h_piqp, lb, ub)
+    solve_start_time = time.perf_counter()
     status = solver.solve()
+    solve_end_time = time.perf_counter()
     success_status = piqp.PIQP_SOLVED
 
     solution = Solution(problem)
@@ -254,6 +258,8 @@ def piqp_solve_problem(
             solution.z_box = solver.result.z_bu - solver.result.z_bl
     else:
         solution.z_box = np.empty((0,))
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/proxqp_.py
+++ b/qpsolvers/solvers/proxqp_.py
@@ -17,6 +17,7 @@ work, consider citing the corresponding paper [Bambade2022]_.
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 from typing import Optional, Union
 
 import numpy as np
@@ -140,6 +141,7 @@ def proxqp_solve_problem(
     This list is not exhaustive. Check out the `solver documentation
     <https://simple-robotics.github.io/proxsuite/>`__ for details.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None:
         if "x" in kwargs:
             raise ParamError(
@@ -155,6 +157,7 @@ def proxqp_solve_problem(
     )
     Cx, ux, lx = combine_linear_box_inequalities(G, h, lb, ub, n, use_csc)
     solve = __select_backend(backend, use_csc)
+    solve_start_time = time.perf_counter()
     result = solve(
         P,
         q,
@@ -166,6 +169,7 @@ def proxqp_solve_problem(
         verbose=verbose,
         **kwargs,
     )
+    solve_end_time = time.perf_counter()
     solution = Solution(problem)
     solution.extras = {"info": result.info}
     solution.found = result.info.status == proxqp.QPSolverOutput.PROXQP_SOLVED
@@ -176,6 +180,8 @@ def proxqp_solve_problem(
         solution.z_box = result.z[-n:]
     else:  # lb is None and ub is None
         solution.z = result.z
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/qpalm_.py
+++ b/qpsolvers/solvers/qpalm_.py
@@ -15,6 +15,7 @@ in a scientific work, consider citing the corresponding paper [Hermans2022]_.
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Optional, Union
 
@@ -98,6 +99,7 @@ def qpalm_solve_problem(
     <https://kul-optec.github.io/QPALM/Doxygen/structqpalm_1_1Settings.html>`__
     for details.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None:
         if "x" in kwargs:
             raise ParamError(
@@ -137,7 +139,9 @@ def qpalm_solve_problem(
                 )
 
     solver = qpalm.Solver(data, settings)
+    solve_start_time = time.perf_counter()
     solver.solve()
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.extras = {"info": solver.info}
@@ -148,6 +152,8 @@ def qpalm_solve_problem(
     solution.y = solver.solution.y[0:m_eq]
     solution.z = solver.solution.y[m_eq : m_eq + m_leq]
     solution.z_box = solver.solution.y[m_eq + m_leq :]
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/qpax_.py
+++ b/qpsolvers/solvers/qpax_.py
@@ -15,6 +15,7 @@ a scientific work, consider citing the corresponding paper [Tracy2024]_.
 **Warm-start:** this solver interface does not support warm starting ❄️
 """
 
+import time
 import warnings
 from typing import Optional
 
@@ -73,6 +74,7 @@ def qpax_solve_problem(
     jax.config.update("jax_enable_x64", True)
     ```
     """
+    build_start_time = time.perf_counter()
     if initvals is not None and verbose:
         warnings.warn("warm-start values are ignored by qpax")
 
@@ -110,6 +112,7 @@ def qpax_solve_problem(
     if isinstance(G, spa.csc_matrix):
         G = G.toarray()
 
+    solve_start_time = time.perf_counter()
     x, s, z, y, converged, iters1 = qpax.solve_qp(
         P,
         q,
@@ -119,6 +122,7 @@ def qpax_solve_problem(
         h,
         **kwargs,
     )
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.x = x
@@ -146,6 +150,8 @@ def qpax_solve_problem(
         },
     }
 
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/qpoases_.py
+++ b/qpsolvers/solvers/qpoases_.py
@@ -20,6 +20,7 @@ on installing this solver.
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Any, List, Optional, Tuple
 
@@ -233,6 +234,7 @@ def qpoases_solve_problem(
     <https://www.coin-or.org/qpOASES/doc/3.1/manual.pdf>`_. for all available
     options.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None:
         warnings.warn("qpOASES: warm-start values are ignored")
 
@@ -260,10 +262,12 @@ def qpoases_solve_problem(
     options = __prepare_options(verbose, predefined_options, **kwargs)
     qp.setOptions(options)
 
+    solve_start_time = time.perf_counter()
     try:
         return_value = qp.init(*args)
     except TypeError as error:
         raise ProblemError("problem has sparse matrices") from error
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.extras = {
@@ -290,6 +294,8 @@ def qpoases_solve_problem(
     solution.z_box = (
         -z_opt[:n] if lb is not None or ub is not None else np.empty((0,))
     )
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/qpswift_.py
+++ b/qpsolvers/solvers/qpswift_.py
@@ -17,6 +17,7 @@ If you use qpSWIFT in your research, consider citing the corresponding paper
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Optional
 
@@ -115,6 +116,7 @@ def qpswift_solve_problem(
     have zero rows in your input matrices, as it can `make the solver
     numerically unstable <https://github.com/qpSWIFT/qpSWIFT/issues/3>`_.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None:
         warnings.warn("qpSWIFT: warm-start values are ignored")
 
@@ -129,6 +131,7 @@ def qpswift_solve_problem(
         }
     )
 
+    solve_start_time = time.perf_counter()
     try:
         if G is not None and h is not None:
             if A is not None and b is not None:
@@ -140,6 +143,7 @@ def qpswift_solve_problem(
             raise ProblemError("problem has no inequality constraint")
     except TypeError as error:
         raise ProblemError("problem has sparse matrices") from error
+    solve_end_time = time.perf_counter()
 
     basic_info = result["basicInfo"]
     adv_info = result["advInfo"]
@@ -157,6 +161,8 @@ def qpswift_solve_problem(
     z, z_box = split_dual_linear_box(adv_info["z"], lb, ub)
     solution.z = z
     solution.z_box = z_box
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/qtqp_.py
+++ b/qpsolvers/solvers/qtqp_.py
@@ -13,6 +13,7 @@ programs (QPs), implemented in pure Python. It is developed by Google DeepMind.
 **Warm-start:** this solver interface does not support warm starting ❄️
 """
 
+import time
 import warnings
 from typing import List, Optional, Union
 
@@ -95,6 +96,7 @@ def qtqp_solve_problem(
     Lower values for absolute or relative tolerances yield more precise
     solutions at the cost of computation time.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None and verbose:
         warnings.warn("QTQP: warm-start values are ignored")
 
@@ -164,7 +166,9 @@ def qtqp_solve_problem(
     )
 
     # Solve the problem
+    solve_start_time = time.perf_counter()
     result = solver.solve(verbose=verbose, **kwargs)
+    solve_end_time = time.perf_counter()
 
     # Build solution
     solution = Solution(problem)
@@ -209,6 +213,8 @@ def qtqp_solve_problem(
         )
         solution.obj += q @ solution.x
 
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/quadprog_.py
+++ b/qpsolvers/solvers/quadprog_.py
@@ -12,6 +12,7 @@ quadprog is a C implementation of the Goldfarb-Idnani dual algorithm
 **Warm-start:** this solver interface does not support warm starting ❄️
 """
 
+import time
 import warnings
 from typing import Optional
 
@@ -67,6 +68,7 @@ def quadprog_solve_problem(
     instance, you can call ``quadprog_solve_qp(P, q, G, h, factorized=True)``.
     See the solver documentation for details.
     """
+    build_start_time = time.perf_counter()
     if initvals is not None and verbose:
         warnings.warn("warm-start values are ignored by quadprog")
 
@@ -96,9 +98,11 @@ def quadprog_solve_problem(
 
     solution = Solution(problem)
     try:
+        solve_start_time = time.perf_counter()
         x, obj, xu, iterations, y, iact = solve_qp(
             qp_G, qp_a, qp_C, qp_b, meq, **kwargs
         )
+        solve_end_time = time.perf_counter()
         solution.found = True
         solution.x = x
         solution.obj = obj
@@ -114,6 +118,7 @@ def quadprog_solve_problem(
             "xu": xu,
         }
     except ValueError as error:
+        solve_end_time = time.perf_counter()
         solution.found = False
         error_message = str(error)
         if "matrix G is not positive definite" in error_message:
@@ -122,6 +127,8 @@ def quadprog_solve_problem(
         if "no solution" not in error_message:
             warnings.warn(f"quadprog raised a ValueError: {error_message}")
 
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/scs_.py
+++ b/qpsolvers/solvers/scs_.py
@@ -14,6 +14,7 @@ work, consider citing the corresponding paper [ODonoghue2021]_.
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Any, Dict, Optional, Union
 
@@ -144,6 +145,7 @@ def scs_solve_problem(
     <https://www.cvxgrp.org/scs/api/settings.html#settings>`_ documentation for
     all available settings.
     """
+    build_start_time = time.perf_counter()
     P, q, G, h, A, b, lb, ub = problem.unpack()
     P, G, A = ensure_sparse_matrices("scs", P, G, A)
     n = P.shape[0]
@@ -174,7 +176,9 @@ def scs_solve_problem(
     if lb is not None or ub is not None:
         __add_box_cone(n, lb, ub, cone, data)
     kwargs["verbose"] = verbose
+    solve_start_time = time.perf_counter()
     result = solve(data, cone, **kwargs)
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.extras = result["info"]
@@ -197,6 +201,8 @@ def scs_solve_problem(
         if lb is not None or ub is not None
         else np.empty((0,))
     )
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/qpsolvers/solvers/sip_.py
+++ b/qpsolvers/solvers/sip_.py
@@ -16,6 +16,7 @@ corresponding GitHub repository (or paper, if one has been released).
 **Warm-start:** this solver interface supports warm starting 🔥
 """
 
+import time
 import warnings
 from typing import Optional, Union
 
@@ -135,6 +136,7 @@ def sip_solve_problem(
     Check the `Settings` struct in the `solver code
     <https://github.com/joaospinto/sip/blob/main/sip/types.hpp>`__ for details.
     """
+    build_start_time = time.perf_counter()
     P, q, G_, h, A_, b, lb, ub = problem.unpack()
     if lb is not None or ub is not None:
         G_, h = linear_from_box_inequalities(
@@ -293,7 +295,9 @@ def sip_solve_problem(
 
     solver = sip.Solver(ss, qs, pd, mc)
 
+    solve_start_time = time.perf_counter()
     output = solver.solve(vars_)
+    solve_end_time = time.perf_counter()
 
     solution = Solution(problem)
     solution.extras = {"sip_output": output, "sip_vars": vars_}
@@ -309,6 +313,8 @@ def sip_solve_problem(
         z, z_box = split_dual_linear_box(z_sip, lb, ub)
         solution.z = z
         solution.z_box = z_box
+    solution.build_time = solve_start_time - build_start_time
+    solution.solve_time = solve_end_time - solve_start_time
     return solution
 
 

--- a/tests/test_timings.py
+++ b/tests/test_timings.py
@@ -1,0 +1,28 @@
+import unittest
+import warnings
+from qpsolvers import available_solvers, solve_problem
+from .problems import get_qpmad_demo_problem
+
+class TestTimings(unittest.TestCase):
+    def test_timings_recorded(self):
+        problem = get_qpmad_demo_problem()
+        
+        for solver in available_solvers:
+            with self.subTest(solver=solver):
+                try:
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        solution = solve_problem(problem, solver=solver)
+                    
+                    self.assertTrue(solution.found, f"Solver {solver} did not find a solution")
+                    self.assertIsNotNone(solution.build_time)
+                    self.assertIsNotNone(solution.solve_time)
+                    self.assertGreaterEqual(solution.build_time, 0.0)
+                    self.assertGreaterEqual(solution.solve_time, 0.0)
+                    
+                    print(f"[{solver}] build_time: {solution.build_time:.6f}s, solve_time: {solution.solve_time:.6f}s")
+                except Exception as e:
+                    print(f"[{solver}] Failed to solve: {e}")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi @stephane-caron,
This PR is an attempt to solve https://github.com/qpsolvers/qpbenchmark/issues/12 and https://github.com/qpsolvers/qpsolvers/issues/255 as you suggested.

Adding some timing info in the `Solution` class, that could be used by `qpbenchmark` to gather info. 

An alternative would be to separate the `<solver_solve_problem` into two stages, setup and solve steps, and do the timing in the `qpbenchmark` library only:
```python
ts = time.perf_counter()
qpoases_setup_qp(....)
setup_duration = time.perf_counter() - ts

ts = time.perf_counter()
res = qpoases_solve_qp(...)
solve_duration = time.perf_counter() - ts
```

To be decided: build_time or setup_time ?
