### PR TITLE
HiGHS: update interface following code changes in HiGHS v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New solver: qpmad (thanks to @ahoarau)
 
+### Fixed
+
+- HiGHS: update interface following code changes in HiGHS v1.14.0
+
 ## [4.11.0] - 2026-03-16
 
 ### Added

--- a/qpsolvers/solvers/highs_.py
+++ b/qpsolvers/solvers/highs_.py
@@ -38,10 +38,11 @@ def __set_hessian(model: highspy.HighsModel, P: spa.csc_matrix) -> None:
     P :
         Positive semidefinite cost matrix.
     """
-    model.hessian_.dim_ = P.shape[0]
-    model.hessian_.start_ = P.indptr
-    model.hessian_.index_ = P.indices
-    model.hessian_.value_ = P.data
+    P_lower = spa.tril(P, format="csc")
+    model.hessian_.dim_ = P_lower.shape[0]
+    model.hessian_.start_ = P_lower.indptr
+    model.hessian_.index_ = P_lower.indices
+    model.hessian_.value_ = P_lower.data
 
 
 def __set_columns(


### PR DESCRIPTION
This PR fixes a HiGHS solver-interface regression with HiGHS 1.14.0.

HiGHS expects only the lower triangle of the Hessian matrix. Previously, `__set_hessian` passed the full symmetric matrix. HiGHS 1.13.1 silently ignored the upper-triangle entries; HiGHS 1.14.0 changed this behaviour to fold them into the lower triangle instead, which corrupted the Hessian and caused the QP solver to immediately hit `Undetermined` status and return `kSolveError`.

**Fix:** apply `scipy.sparse.tril` before passing the Hessian to HiGHS, so only the lower triangle is ever sent regardless of HiGHS version.

See also https://github.com/ERGO-Code/HiGHS/issues/2960.