### PR TITLE
OSQP: Handle optional `raise_error` keyword argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- OSQP: Handle optional `raise_error` keyword argument to the solve function
+
 ## [4.12.0] - 2026-05-05
 
 ### Added

--- a/doc/developer-notes.rst
+++ b/doc/developer-notes.rst
@@ -53,7 +53,7 @@ The process to add AwesomeQP to *qpsolvers* goes as follows:
 
 .. note::
 
-    The prototype needs to match the actual function. You can check its correctness by running ``tox -e py`` in the repository.
+    The prototype needs to match the actual function. You can check its correctness by running ``pixi run test`` in the repository.
 
 5. Below the prototype, import the function into the ``solve_function`` dictionary:
 
@@ -87,10 +87,16 @@ Problem conversions
 Testing locally
 ===============
 
-To run all CI checks locally, go to the repository folder and run
+This project uses `pixi <https://pixi.sh/latest>`_ for testing and linting locally. To check unit tests from your working copy of the repository, run:
 
 .. code:: bash
 
-    tox -e py
+    pixi run test
 
-This will run linters and unit tests.
+To check linting, run similarly:
+
+.. code:: bash
+
+   pixi run lint
+
+Pixi will take care of creating local Python environments with all the dependencies needed for linting or testing.

--- a/qpsolvers/solvers/osqp_.py
+++ b/qpsolvers/solvers/osqp_.py
@@ -131,13 +131,18 @@ def osqp_solve_problem(
         u_osqp = ub if u_osqp is None else np.hstack([u_osqp, ub])
 
     kwargs["verbose"] = verbose
+    kwargs_solve = (
+        {"raise_error": kwargs.pop("raise_error")}
+        if "raise_error" in kwargs
+        else {}
+    )
     solver = OSQP()
     solver.setup(P=P, q=q, A=A_osqp, l=l_osqp, u=u_osqp, **kwargs)
     if initvals is not None:
         solver.warm_start(x=initvals)
 
     solve_start_time = time.perf_counter()
-    res = solver.solve()
+    res = solver.solve(**kwargs_solve)
     solve_end_time = time.perf_counter()
 
     solution = Solution(problem)

--- a/qpsolvers/solvers/osqp_.py
+++ b/qpsolvers/solvers/osqp_.py
@@ -71,9 +71,9 @@ def osqp_solve_problem(
 
     Notes
     -----
-    Keyword arguments are forwarded to OSQP. For instance, we can call
-    ``osqp_solve_qp(P, q, G, h, u, eps_abs=1e-8, eps_rel=0.0)``. OSQP settings
-    include the following:
+    Keyword arguments are forwarded to either the setup or the solve function
+    of OSQP. For instance, we can call ``osqp_solve_qp(P, q, G, h, u,
+    eps_abs=1e-8, eps_rel=0.0)``. OSQP settings include the following:
 
     .. list-table::
        :widths: 30 70
@@ -98,6 +98,10 @@ def osqp_solve_problem(
        * - ``polish``
          - Perform polishing. See `Polishing
            <https://osqp.org/docs/solver/#polishing>`_.
+       * - ``raise_error``
+         - If ``True``, raise an exception if the solver does not find a
+           solution. See `Solve
+           <https://osqp.org/docs/interfaces/python.html#solve>`_.
 
     Check out the `OSQP settings
     <https://osqp.org/docs/interfaces/solver_settings.html>`_ documentation for

--- a/tests/test_osqp.py
+++ b/tests/test_osqp.py
@@ -18,14 +18,16 @@ try:
         """Tests specific to OSQP."""
 
         def test_problem(self):
+            """Solve a standard QP with OSQP."""
             problem = get_sd3310_problem()
             P, q, G, h, A, b, lb, ub = problem.unpack()
             self.assertIsNotNone(osqp_solve_qp(P, q, G, h, A, b, lb, ub))
 
         def test_raise_error_kwarg(self):
-            # raise_error is a solve() param, not a setup() param; passing it
-            # must not raise ValueError from OSQP's settings validation
-            # https://github.com/qpsolvers/qpsolvers/issues/380
+            """The `raise_error` OSQP kwarg should be forwarded to solve().
+
+            See https://github.com/qpsolvers/qpsolvers/issues/380
+            """
             problem = get_sd3310_problem()
             P, q, G, h, A, b, lb, ub = problem.unpack()
             self.assertIsNotNone(

--- a/tests/test_osqp.py
+++ b/tests/test_osqp.py
@@ -22,5 +22,15 @@ try:
             P, q, G, h, A, b, lb, ub = problem.unpack()
             self.assertIsNotNone(osqp_solve_qp(P, q, G, h, A, b, lb, ub))
 
+        def test_raise_error_kwarg(self):
+            # raise_error is a solve() param, not a setup() param; passing it
+            # must not raise ValueError from OSQP's settings validation
+            # https://github.com/qpsolvers/qpsolvers/issues/380
+            problem = get_sd3310_problem()
+            P, q, G, h, A, b, lb, ub = problem.unpack()
+            self.assertIsNotNone(
+                osqp_solve_qp(P, q, G, h, A, b, lb, ub, raise_error=True)
+            )
+
 except ImportError as exn:  # solver not installed
     warnings.warn(f"Skipping OSQP tests: {exn}")


### PR DESCRIPTION
This PR adds handling of the optional `raise_error` argument to [OSQP's solve function](https://osqp.org/docs/interfaces/python.html#solve), as suggested by @vincentvaroquauxads in https://github.com/qpsolvers/qpsolvers/issues/380.