### PR TITLE
Transfer copyright notices to a `NOTICE` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- docs: Update note on adding a new solver
+- Transfer copyright notices to a single NOTICE file
+
 ## [4.13.0] - 2026-07-19
 
 ### Added
@@ -15,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pre-commit configuration for local linting (thanks to @ahoarau)
 - Update CI Actions and pixi versions to latest (thanks to @ahoarau)
 
-### Updated
+### Changed
 
 - SIP: Use the `sip-qp-python` v0.0.2 QP frontend
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+This project includes contributions made under the following copyrights:
+
+- Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
+- Copyright 2021 Dustin Kenefake
+- Copyright 2023-2025 Inria
+- Copyright 2024 Lev Kozlov
+- Copyright 2026 CNRS

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2024 Stéphane Caron and the qpsolvers contributors
 
 import re
 import sys

--- a/doc/developer-notes.rst
+++ b/doc/developer-notes.rst
@@ -73,8 +73,8 @@ The process to add AwesomeQP to *qpsolvers* goes as follows:
 7. Import ``awesomeqp_solve_qp`` from ``qpsolvers/__init__.py`` and add it to ``__all__``
 8. Add the solver to ``doc/src/supported-solvers.rst``
 9. Add the solver to the *Solvers* section of the README
-10. Assuming AwesomeQP is distributed on `PyPI <https://pypi.org/>`__, add it to the ``[testenv]`` and ``[testenv:coverage]`` environments of ``tox.ini`` for unit testing
-11. Assuming AwesomeQP is distributed on Conda or PyPI, add it to the list of dependencies in ``doc/environment.yml``
+10. If AwesomeQP is distributed on `PyPI <https://pypi.org/>`__, add it to ``[tool.pixi.pypi-dependencies]`` in ``pyproject.toml`` (you can also add an entry for it in ``[project.optional-dependencies]``)
+11. If AwesomeQP is distributed on Conda, add it to ``[tool.pixi.dependencies]`` in ``pyproject.toml``
 12. Log the new solver as an addition in the changelog
 13. If you are a new contributor, feel free to add your name to ``CITATION.cff``.
 

--- a/examples/box_inequalities.py
+++ b/examples/box_inequalities.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Test an available QP solvers on a small problem with box inequalities."""
 

--- a/examples/constrained_linear_regression.py
+++ b/examples/constrained_linear_regression.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Test a random QP solver on a constrained linear regression problem.
 

--- a/examples/dual_multipliers.py
+++ b/examples/dual_multipliers.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Get both primal and dual solutions to a quadratic program."""
 

--- a/examples/lasso_regularization.py
+++ b/examples/lasso_regularization.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Apply lasso regularization to a quadratic program.
 

--- a/examples/least_squares.py
+++ b/examples/least_squares.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Test a random available QP solver on a small least-squares problem."""
 

--- a/examples/model_predictive_control.py
+++ b/examples/model_predictive_control.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Test the "quadprog" QP solver on a model predictive control problem.
 

--- a/examples/quadratic_program.py
+++ b/examples/quadratic_program.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Test the "quadprog" QP solver on a small dense problem."""
 

--- a/examples/sparse_least_squares.py
+++ b/examples/sparse_least_squares.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Test a random sparse QP solver on a sparse least-squares problem.
 

--- a/examples/test_dense_problem.py
+++ b/examples/test_dense_problem.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Test all available QP solvers on a dense quadratic program."""
 

--- a/examples/test_model_predictive_control.py
+++ b/examples/test_model_predictive_control.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Test all available QP solvers on a model predictive control problem."""
 

--- a/examples/test_random_problems.py
+++ b/examples/test_random_problems.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Test all available QP solvers on random quadratic programs."""
 

--- a/examples/test_sparse_problem.py
+++ b/examples/test_sparse_problem.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Test all available QP solvers on a sparse quadratic program."""
 

--- a/qpsolvers/__init__.py
+++ b/qpsolvers/__init__.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Quadratic programming solvers in Python with a unified API."""
 

--- a/qpsolvers/active_set.py
+++ b/qpsolvers/active_set.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2023 Inria
 
 """Active set: indices of inequality constraints saturated at the optimum."""
 

--- a/qpsolvers/conversions/__init__.py
+++ b/qpsolvers/conversions/__init__.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Convert problems from and to standard QP form."""
 

--- a/qpsolvers/conversions/combine_linear_box_inequalities.py
+++ b/qpsolvers/conversions/combine_linear_box_inequalities.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2023 Stéphane Caron and the qpsolvers contributors
 
 """Combine linear and box inequalities into double-sided linear format."""
 

--- a/qpsolvers/conversions/ensure_sparse_matrices.py
+++ b/qpsolvers/conversions/ensure_sparse_matrices.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Make sure problem matrices are sparse."""
 

--- a/qpsolvers/conversions/linear_from_box_inequalities.py
+++ b/qpsolvers/conversions/linear_from_box_inequalities.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Functions to convert vector bounds into linear inequality constraints."""
 

--- a/qpsolvers/conversions/socp_from_qp.py
+++ b/qpsolvers/conversions/socp_from_qp.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Convert quadratic programs to second-order cone programs."""
 

--- a/qpsolvers/conversions/split_dual_linear_box.py
+++ b/qpsolvers/conversions/split_dual_linear_box.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Convert stacked dual multipliers into linear and box multipliers."""
 

--- a/qpsolvers/exceptions.py
+++ b/qpsolvers/exceptions.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """
 Exceptions from qpsolvers.

--- a/qpsolvers/problem.py
+++ b/qpsolvers/problem.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Model for a quadratic program."""
 

--- a/qpsolvers/problems.py
+++ b/qpsolvers/problems.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2023 Stéphane Caron and the qpsolvers contributors
 
 """Collection of sample problems."""
 

--- a/qpsolvers/solution.py
+++ b/qpsolvers/solution.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Output from a QP solver."""
 

--- a/qpsolvers/solve_ls.py
+++ b/qpsolvers/solve_ls.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solve linear least squares."""
 

--- a/qpsolvers/solve_problem.py
+++ b/qpsolvers/solve_problem.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solve quadratic programs."""
 

--- a/qpsolvers/solve_qp.py
+++ b/qpsolvers/solve_qp.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solve quadratic programs."""
 

--- a/qpsolvers/solve_unconstrained.py
+++ b/qpsolvers/solve_unconstrained.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2023 Inria
 
 """Solve an unconstrained quadratic program."""
 

--- a/qpsolvers/solvers/__init__.py
+++ b/qpsolvers/solvers/__init__.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Import available QP solvers."""
 

--- a/qpsolvers/solvers/clarabel_.py
+++ b/qpsolvers/solvers/clarabel_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2023 Inria
 
 """Solver interface for `Clarabel.rs`_.
 

--- a/qpsolvers/solvers/copt_.py
+++ b/qpsolvers/solvers/copt_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `COPT <https://www.shanshu.ai/solver>`__.
 

--- a/qpsolvers/solvers/cvxopt_.py
+++ b/qpsolvers/solvers/cvxopt_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `CVXOPT <https://cvxopt.org/>`__.
 

--- a/qpsolvers/solvers/daqp_.py
+++ b/qpsolvers/solvers/daqp_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `DAQP <https://github.com/darnstrom/daqp>`__.
 

--- a/qpsolvers/solvers/ecos_.py
+++ b/qpsolvers/solvers/ecos_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `ECOS <https://github.com/embotech/ecos>`__.
 

--- a/qpsolvers/solvers/gurobi_.py
+++ b/qpsolvers/solvers/gurobi_.py
@@ -2,8 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
-# Copyright 2021 Dustin Kenefake
 
 """Solver interface for `Gurobi <https://www.gurobi.com/>`__.
 

--- a/qpsolvers/solvers/highs_.py
+++ b/qpsolvers/solvers/highs_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `HiGHS <https://github.com/ERGO-Code/HiGHS>`__.
 

--- a/qpsolvers/solvers/hpipm_.py
+++ b/qpsolvers/solvers/hpipm_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `HPIPM <https://github.com/giaf/hpipm>`__.
 

--- a/qpsolvers/solvers/jaxopt_osqp_.py
+++ b/qpsolvers/solvers/jaxopt_osqp_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2024 Lev Kozlov
 
 """
 Solver interface for jaxopt's implementation of the OSQP algorithm.

--- a/qpsolvers/solvers/kvxopt_.py
+++ b/qpsolvers/solvers/kvxopt_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `KVXOPT <https://github.com/sanurielf/kvxopt>`__.
 

--- a/qpsolvers/solvers/mosek_.py
+++ b/qpsolvers/solvers/mosek_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `MOSEK <https://www.mosek.com/>`__.
 

--- a/qpsolvers/solvers/nppro_.py
+++ b/qpsolvers/solvers/nppro_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2023 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for NPPro.
 

--- a/qpsolvers/solvers/osqp_.py
+++ b/qpsolvers/solvers/osqp_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `OSQP <https://osqp.org/>`__.
 

--- a/qpsolvers/solvers/pdhcg_.py
+++ b/qpsolvers/solvers/pdhcg_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for PDHCG.
 

--- a/qpsolvers/solvers/piqp_.py
+++ b/qpsolvers/solvers/piqp_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `PIQP`_.
 

--- a/qpsolvers/solvers/proxqp_.py
+++ b/qpsolvers/solvers/proxqp_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `ProxQP`_.
 

--- a/qpsolvers/solvers/pyqpmad_.py
+++ b/qpsolvers/solvers/pyqpmad_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `pyqpmad <https://github.com/ahoarau/pyqpmad>`__.
 

--- a/qpsolvers/solvers/qpalm_.py
+++ b/qpsolvers/solvers/qpalm_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `QPALM`_.
 

--- a/qpsolvers/solvers/qpax_.py
+++ b/qpsolvers/solvers/qpax_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2024 Lev Kozlov
 
 """
 Solver interface for `qpax <https://github.com/kevin-tracy/qpax>`__.

--- a/qpsolvers/solvers/qpoases_.py
+++ b/qpsolvers/solvers/qpoases_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `qpOASES <https://github.com/coin-or/qpOASES>`__.
 

--- a/qpsolvers/solvers/qpswift_.py
+++ b/qpsolvers/solvers/qpswift_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `qpSWIFT <https://github.com/qpSWIFT/qpSWIFT>`__.
 

--- a/qpsolvers/solvers/quadprog_.py
+++ b/qpsolvers/solvers/quadprog_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `quadprog <https://github.com/quadprog/quadprog>`__.
 

--- a/qpsolvers/solvers/scs_.py
+++ b/qpsolvers/solvers/scs_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `SCS <https://www.cvxgrp.org/scs/>`__.
 

--- a/qpsolvers/solvers/sip_.py
+++ b/qpsolvers/solvers/sip_.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Solver interface for `SIP`_.
 

--- a/qpsolvers/utils.py
+++ b/qpsolvers/utils.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Utility functions."""
 

--- a/qpsolvers/warnings.py
+++ b/qpsolvers/warnings.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2025 Inria
 
 """Warnings from qpsolvers."""
 

--- a/tests/problems.py
+++ b/tests/problems.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 import numpy as np
 

--- a/tests/test_clarabel.py
+++ b/tests/test_clarabel.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for Clarabel."""
 

--- a/tests/test_combine_linear_box_inequalities.py
+++ b/tests/test_combine_linear_box_inequalities.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for the `solve_qp` function."""
 

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for internal conversion functions."""
 

--- a/tests/test_copt.py
+++ b/tests/test_copt.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for COPT."""
 

--- a/tests/test_cvxopt.py
+++ b/tests/test_cvxopt.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for CVXOPT."""
 

--- a/tests/test_ecos.py
+++ b/tests/test_ecos.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for ECOS."""
 

--- a/tests/test_gurobi.py
+++ b/tests/test_gurobi.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for Gurobi."""
 

--- a/tests/test_highs.py
+++ b/tests/test_highs.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for HiGHS."""
 

--- a/tests/test_jaxopt_osqp.py
+++ b/tests/test_jaxopt_osqp.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2025 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for jaxopt.OSQP."""
 

--- a/tests/test_kvxopt.py
+++ b/tests/test_kvxopt.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for KVXOPT."""
 

--- a/tests/test_mosek.py
+++ b/tests/test_mosek.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for MOSEK."""
 

--- a/tests/test_nppro.py
+++ b/tests/test_nppro.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 import unittest
 import warnings

--- a/tests/test_osqp.py
+++ b/tests/test_osqp.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for OSQP."""
 

--- a/tests/test_piqp.py
+++ b/tests/test_piqp.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for PIQP."""
 

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for Problem class."""
 

--- a/tests/test_proxqp.py
+++ b/tests/test_proxqp.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for ProxQP."""
 

--- a/tests/test_pyqpmad.py
+++ b/tests/test_pyqpmad.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2024 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for pyqpmad."""
 

--- a/tests/test_qpax.py
+++ b/tests/test_qpax.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2024 Lev Kozlov
 
 """Unit tests for qpax."""
 

--- a/tests/test_qpoases.py
+++ b/tests/test_qpoases.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for qpOASES."""
 

--- a/tests/test_qpswift.py
+++ b/tests/test_qpswift.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for qpSWIFT."""
 

--- a/tests/test_quadprog.py
+++ b/tests/test_quadprog.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for quadprog."""
 

--- a/tests/test_scs.py
+++ b/tests/test_scs.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for SCS."""
 

--- a/tests/test_sip.py
+++ b/tests/test_sip.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for SIP."""
 

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for Solution class."""
 

--- a/tests/test_solve_ls.py
+++ b/tests/test_solve_ls.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for the `solve_ls` function."""
 

--- a/tests/test_solve_problem.py
+++ b/tests/test_solve_problem.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2023 Inria
 
 """Unit tests for the `solve_problem` function."""
 

--- a/tests/test_solve_qp.py
+++ b/tests/test_solve_qp.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for the `solve_qp` function."""
 

--- a/tests/test_unfeasible_problem.py
+++ b/tests/test_unfeasible_problem.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests with unfeasible problems."""
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
-# Copyright 2016-2022 Stéphane Caron and the qpsolvers contributors
 
 """Unit tests for utility functions."""
 


### PR DESCRIPTION
This will keep the information preserved while eliminating per-file clutter, reducing merge conflicts, and making attribution easier to maintain and review in one place.