### PR TITLE
qpSWIFT: handle infinite values in linear inequalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MOSEK: handle infinite values in linear inequalities
 - PIQP: handle infinite values in linear inequalities
 - SCS: handle infinite values in linear inequalities
+- qpSWIFT: handle infinite values in linear inequalities
 - qtqp: handle infinite values in linear inequalities
 
 ## [4.13.0] - 2026-07-19

--- a/qpsolvers/solvers/qpswift_.py
+++ b/qpsolvers/solvers/qpswift_.py
@@ -23,7 +23,12 @@ from typing import Optional
 import numpy as np
 import qpSWIFT
 
-from ..conversions import linear_from_box_inequalities, split_dual_linear_box
+from ..conversions import (
+    linear_from_box_inequalities,
+    put_infinite_inequalities_back,
+    remove_infinite_inequalities,
+    split_dual_linear_box,
+)
 from ..exceptions import ProblemError
 from ..problem import Problem
 from ..solution import Solution
@@ -122,6 +127,12 @@ def qpswift_solve_problem(
     P, q, G, h, A, b, lb, ub = problem.unpack()
     if lb is not None or ub is not None:
         G, h = linear_from_box_inequalities(G, h, lb, ub, use_sparse=False)
+
+    # qpSWIFT does not handle infinite values in inequality vectors,
+    # so we drop rows of h equal to +infinity
+    finite_h: Optional[np.ndarray] = None
+    if G is not None and h is not None:
+        G, h, finite_h = remove_infinite_inequalities(G, h)
     result: dict = {}
     kwargs.update(
         {
@@ -157,7 +168,10 @@ def qpswift_solve_problem(
     solution.found = exit_flag == 0
     solution.x = result["sol"]
     solution.y = adv_info["y"] if A is not None else np.empty((0,))
-    z, z_box = split_dual_linear_box(adv_info["z"], lb, ub)
+    z_ineq = adv_info["z"]
+    if finite_h is not None:
+        z_ineq = put_infinite_inequalities_back(z_ineq, finite_h)
+    z, z_box = split_dual_linear_box(z_ineq, lb, ub)
     solution.z = z
     solution.z_box = z_box
     solution.build_time = solve_start_time - build_start_time

--- a/tests/test_solve_problem.py
+++ b/tests/test_solve_problem.py
@@ -527,17 +527,15 @@ for solver in available_solvers:
             f"test_qptest_{solver}",
             TestSolveProblem.get_test_qptest(solver),
         )
-    if solver not in ["ecos", "qpswift"]:
-        # See https://github.com/qpsolvers/qpsolvers/issues/159
-        # See https://github.com/qpsolvers/qpsolvers/issues/160
+    # ECOS does not handle infinite values in inequality vectors:
+    # https://github.com/qpsolvers/qpsolvers/issues/160
+    if solver != "ecos":
         setattr(
             TestSolveProblem,
             f"test_infinite_box_bounds_{solver}",
             TestSolveProblem.get_test_infinite_box_bounds(solver),
         )
-    if solver not in ["ecos", "qpswift"]:
-        # See https://github.com/qpsolvers/qpsolvers/issues/159
-        # See https://github.com/qpsolvers/qpsolvers/issues/160
+    if solver != "ecos":
         setattr(
             TestSolveProblem,
             f"test_infinite_linear_bounds_{solver}",
@@ -553,7 +551,8 @@ for solver in available_solvers:
         f"test_qpgurabs_{solver}",
         TestSolveProblem.get_test_qpgurabs(solver),
     )
-    if solver != "qtqp":  # QTQP requires at least one inequality constraint
+    # QTQP and qpSWIFT require at least one inequality constraint
+    if solver not in ["qtqp", "qpswift"]:
         setattr(
             TestSolveProblem,
             f"test_qpgureq_{solver}",


### PR DESCRIPTION
Closes https://github.com/qpsolvers/qpsolvers/issues/159

I tested the fix on a manual local installation of the solver. qpSWIFT [is currently](https://github.com/qpsolvers/qpsolvers/blob/84030150316f7b72e50bf0e85c7f65dd0d58c9a7/doc/unsupported-solvers.rst#qpswift) an unsupported solver, so the fix won't be checked by continuous integration.